### PR TITLE
Minor backend refactorying. Skipping verify-keccak.

### DIFF
--- a/packages/backend/.vscode/tasks.json
+++ b/packages/backend/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "cargo build",
+            "type": "shell",
+            "command": "cargo",
+            "args": [
+                "build"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": ["$rustc"],
+            "detail": "Build Rust project for debugging"
+        }
+    ]
+}

--- a/packages/backend/libs/src/bivariate_polynomial/mod.rs
+++ b/packages/backend/libs/src/bivariate_polynomial/mod.rs
@@ -280,6 +280,7 @@ where
     fn _biNTT<In: HostOrDeviceSlice<Self::Field> + ?Sized, Out: HostOrDeviceSlice<Self::Field> + ?Sized>( in_mat: &In, x_size: usize, y_size: usize, dir: NTTDir, out_mat: &mut Out);
 
     // Methods to create polynomials from coefficients or roots-of-unity evaluations.
+    fn zero() -> Self;
     fn from_coeffs<S: HostOrDeviceSlice<Self::Field> + ?Sized>(coeffs: &S, x_size: usize, y_size: usize) -> Self;
     fn from_rou_evals<S: HostOrDeviceSlice<Self::Field> + ?Sized>(evals: &S, x_size: usize, y_size: usize, coset_x: Option<&Self::Field>, coset_y: Option<&Self::Field>) -> Self;
 
@@ -480,15 +481,27 @@ impl BivariatePolynomial for DensePolynomialExt {
         (x_deg, y_deg)
     }
 
-    fn from_coeffs<S: HostOrDeviceSlice<Self::Field> + ?Sized>(coeffs: &S, x_size: usize, y_size: usize) -> Self {
-        if x_size == 0 || y_size == 0 {
-            panic!("Invalid matrix size for from_coeffs");
+    fn zero() -> Self {
+        let zero_vec = [Self::Field::zero()];
+        Self {
+            poly: DensePolynomial::from_coeffs(HostSlice::from_slice(&zero_vec), 1),
+            x_degree: -1,
+            y_degree: -1,
+            x_size: 1,
+            y_size: 1,
         }
+    }
+    fn from_coeffs<S: HostOrDeviceSlice<Self::Field> + ?Sized>(coeffs: &S, x_size: usize, y_size: usize) -> Self {
+        
         if x_size * y_size != coeffs.len() {
             panic!("Mismatch between the coefficient vector and the polynomial size")
         }
         if x_size.is_power_of_two() == false || y_size.is_power_of_two() == false {
             panic!("The input sizes for from_coeffs must be powers of two.")
+        }
+        let size = x_size + y_size;
+        if size == 0 {
+            return Self::zero()
         }
         let poly = DensePolynomial::from_coeffs(coeffs, x_size * y_size);
         //let (x_degree, y_degree) = DensePolynomialExt::_find_degree(&poly, x_size, y_size);
@@ -562,53 +575,18 @@ impl BivariatePolynomial for DensePolynomialExt {
         coset_x: Option<&Self::Field>,
         coset_y: Option<&Self::Field>
     ) -> Self {
-        if x_size == 0 || y_size == 0 {
-            panic!("Invalid matrix size for from_rou_evals");
-        }
         if !x_size.is_power_of_two() || !y_size.is_power_of_two() {
             panic!("The input sizes for from_rou_evals must be powers of two.")
         }
     
         let size = x_size * y_size;
-    
-        ntt::initialize_domain::<Self::Field>(
-            ntt::get_root_of_unity::<Self::Field>(size.try_into().unwrap()),
-            &ntt::NTTInitDomainConfig::default(),
-        ).unwrap();
-    
+        if size == 0 {
+            return Self::zero()
+        }
         let mut coeffs = DeviceVec::<Self::Field>::device_malloc(size).unwrap();
-        let mut cfg = ntt::NTTConfig::<Self::Field>::default();
 
-        let mut input_tr = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
-        let mut output_tr = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
-        let vec_ops_cfg = VecOpsConfig::default();
-
-        ScalarCfg::transpose(
-            evals,
-            x_size as u32,
-            y_size as u32,
-            &mut input_tr,
-            &vec_ops_cfg,
-        ).unwrap();
-
-        cfg.batch_size = y_size as i32;
-        cfg.columns_batch = false;
-        ntt::ntt(&input_tr, ntt::NTTDir::kInverse, &cfg, &mut output_tr).unwrap();
-
-        ScalarCfg::transpose(
-            &output_tr,
-            y_size as u32,
-            x_size as u32,
-            &mut coeffs,
-            &vec_ops_cfg,
-        ).unwrap();
-    
-
-        cfg.batch_size = x_size as i32;
-        cfg.columns_batch = false;
-        ntt::ntt_inplace(&mut coeffs, ntt::NTTDir::kInverse, &cfg).unwrap();
-    
-        ntt::release_domain::<Self::Field>().unwrap();
+        let ntt_dir = ntt::NTTDir::kInverse;
+        Self::_biNTT(evals, x_size, y_size, ntt_dir, &mut coeffs);
     
         let mut poly = DensePolynomialExt::from_coeffs(
             &coeffs,
@@ -655,53 +633,11 @@ impl BivariatePolynomial for DensePolynomialExt {
             scaled_poly.copy_coeffs(0, scaled_coeffs);
         }
         
-        ntt::initialize_domain::<Self::Field>(
-            ntt::get_root_of_unity::<Self::Field>(
-                size.try_into()
-                    .unwrap(),
-            ),
-            &ntt::NTTInitDomainConfig::default(),
-        ).unwrap();
-        
-        let mut cfg = ntt::NTTConfig::<Self::Field>::default();
-       
-        let mut input_tr = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
-        let mut output_tr = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
-        let vec_ops_cfg = VecOpsConfig::default();
+        let mut in_mat = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+        in_mat.copy_from_host(&scaled_coeffs).unwrap();
 
-        input_tr.copy_from_host(&scaled_coeffs).unwrap();
-
-        ScalarCfg::transpose(
-            &input_tr,
-            self.x_size as u32,
-            self.y_size as u32,
-            &mut output_tr,
-            &vec_ops_cfg,
-        ).unwrap();
-
-        let mut out_b = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
-
-        cfg.batch_size = self.y_size as i32;
-        cfg.columns_batch = false;
-
-        ntt::ntt(&output_tr, ntt::NTTDir::kForward, &cfg, &mut out_b).unwrap();
-
-        ScalarCfg::transpose(
-            &out_b,
-            self.y_size as u32,
-            self.x_size as u32,
-            evals,
-            &vec_ops_cfg,
-        ).unwrap();
-        
-        drop(scaled_coeffs_vec);
-        
-        // FFT along Y
-        cfg.batch_size = self.x_size as i32;
-        cfg.columns_batch = false;
-        
-        ntt::ntt_inplace(evals, ntt::NTTDir::kForward, &cfg).unwrap();
-        ntt::release_domain::<Self::Field>().unwrap();
+        let ntt_dir = ntt::NTTDir::kForward;
+        Self::_biNTT(&in_mat, self.x_size, self.y_size, ntt_dir, evals);
     }
 
     fn copy_coeffs<S: HostOrDeviceSlice<Self::Field> + ?Sized>(&self, start_idx: u64, coeffs: &mut S) {
@@ -709,8 +645,7 @@ impl BivariatePolynomial for DensePolynomialExt {
     }
 
     fn _neg(&self) -> Self {
-        let zero_vec = vec![Self::Field::zero(); 1];
-        let zero_poly = DensePolynomialExt::from_coeffs(HostSlice::from_slice(&zero_vec), 1, 1);
+        let zero_poly = Self::zero();
         &zero_poly - self
     }
 

--- a/packages/backend/libs/src/iotools/mod.rs
+++ b/packages/backend/libs/src/iotools/mod.rs
@@ -516,9 +516,7 @@ impl QAP{
         let global_wire_file_name = "globalWireList.json";
         let global_wire_list = read_global_wire_list_as_boxed_boxed_numbers(global_wire_file_name).unwrap();
 
-        let zero_coef_vec = [ScalarField::zero()];
-        let zero_coef = HostSlice::from_slice(&zero_coef_vec);
-        let zero_poly = DensePolynomialExt::from_coeffs(zero_coef, 1, 1);
+        let zero_poly = DensePolynomialExt::zero();
         let mut u_j_X = vec![zero_poly.clone(); m_d];
         let mut v_j_X = vec![zero_poly.clone(); m_d];
         let mut w_j_X = vec![zero_poly.clone(); m_d];

--- a/packages/backend/libs/src/polynomial_structures/mod.rs
+++ b/packages/backend/libs/src/polynomial_structures/mod.rs
@@ -28,9 +28,7 @@ pub fn from_subcircuit_to_QAP(
     let n = setup_params.n;
 
     // Reconstruct local u,v,w polynomials
-    let zero_coef_vec = [ScalarField::zero()];
-    let zero_coef = HostSlice::from_slice(&zero_coef_vec);
-    let zero_poly = DensePolynomialExt::from_coeffs(zero_coef, 1, 1);
+    let zero_poly = DensePolynomialExt::zero();
     let mut u_j_X = vec![zero_poly.clone(); subcircuit_info.Nwires];
     let mut v_j_X = vec![zero_poly.clone(); subcircuit_info.Nwires];
     let mut w_j_X = vec![zero_poly.clone(); subcircuit_info.Nwires];

--- a/packages/backend/verify/verify-rust/src/lib.rs
+++ b/packages/backend/verify/verify-rust/src/lib.rs
@@ -14,6 +14,13 @@ use libs::group_structures::pairing;
 
 use std::vec;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeccakVerificationResult {
+    True,
+    False,
+    NoKeccakData,
+}
+
 pub struct Verifier {
     pub sigma: SigmaVerify,
     pub a_pub: Box<[ScalarField]>,
@@ -95,10 +102,13 @@ impl Verifier {
         }
     }
 
-    pub fn verify_keccak256(&self) -> bool {
+    pub fn verify_keccak256(&self) -> KeccakVerificationResult {
         let l_pub_out = self.setup_params.l_pub_out;
         let keccak_in_pts = &self.publicOutputBuffer.outPts;
         let keccak_out_pts = &self.publicInputBuffer.inPts;
+        if keccak_out_pts.len() == 0 {
+            return KeccakVerificationResult::NoKeccakData
+        }
         
         let mut keccak_inputs_be_bytes= Vec::new();
         let mut prev_key: usize = 0;
@@ -165,7 +175,7 @@ impl Verifier {
         keccak_outputs_be_bytes.push(data_restored);
 
         let keccak_hasher = Keccak256::new(0 /* default input size */).unwrap();
-        let mut flag = true;
+        let mut flag = KeccakVerificationResult::True;
         if keccak_inputs_be_bytes.len() != keccak_outputs_be_bytes.len() {
             panic!("Length mismatch between Keccak inputs and outputs.")
         }
@@ -180,7 +190,7 @@ impl Verifier {
             )
             .unwrap();
             if res_bytes != keccak_outputs_be_bytes[i] {
-                flag = false;
+                flag = KeccakVerificationResult::False;
             }
         }
         return flag


### PR DESCRIPTION
## Description
Minor code structure updates in the bivariate polynomial library.
In rust-verifier, verifying keccak data can be skipped if the public input and output buffers are empty (previously it threw an error of dealing with an empty array)

## Related Issue
<!-- Please link to the issue here -->
Closes #

## Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🔥 Breaking Change
- [ ] 🌟 New Feature
- [ O ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ O ] 🔧 Code Refactoring
- [ ] 📈 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Testing
Testing transaction 1: 0x3967fc48fafbee4de2d34655925dae0bb3070807251d5b4569997a58a46586bc
Testing transaction 2 (empty public in&out buffers): 0x08347807190cb257fa5c64a38e240f22ed96c1b36e492dd6981fc30f91292fb9
- [ ] Unit Tests
- [ ] Integration Tests
- [ O ] Manual Tests