### PR TITLE
Add Dockerfile and docker-compose.yaml for easier setup on Linux

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+services:
+  cli:
+    build: ./
+    volumes:
+      - ./:/app
+    working_dir: /app
+    tty: true       
+    stdin_open: true
+    environment:
+      - TOKAMAK_ZK_EVM_ROOT=/app

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:latest
+# ---------- OS packages ----------
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y \
+        git curl make build-essential unzip pkg-config libssl-dev jq \
+        git-lfs \
+        cmake \
+        dos2unix
+
+# ---------- Rust ----------
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# ---------- Circom ----------
+RUN git clone https://github.com/iden3/circom.git /tmp/circom \
+ && cd /tmp/circom && cargo build --release \
+ && cp /tmp/circom/target/release/circom /usr/local/bin/ \
+ && rm -rf /tmp/circom
+
+# ---------- Node ----------
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+RUN apt-get install -y nodejs
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN npm install -g pnpm
+RUN pnpm add -g snarkjs
+
+# ---------- Foundry (forge / anvil) ----------
+RUN curl -L https://foundry.paradigm.xyz | bash \
+ && ~/.foundry/bin/foundryup


### PR DESCRIPTION
## Description
This PR adds a `Dockerfile` and `docker-compose.yaml` to simplify the setup process for Linux users.
It installs the [required packages](https://github.com/tokamak-network/Tokamak-zk-EVM?tab=readme-ov-file#for-linux-users) and allows users to get started quickly by running:

```bash
docker-compose up
```

I would also recommend mentioning public RPC endpoints in the documentation for those who just want to try the project quickly without creating an API key.

For example, I successfully installed using:

```bash
./tokamak-cli --install https://cloudflare-eth.com/
```

instead of using RPC endpoints that require API keys.

---

Additionally, during the [verification step](https://github.com/tokamak-network/Tokamak-zk-EVM?tab=readme-ov-file#how-to-run-for-all-platforms),
I initially tried:

```bash
./tokamak-cli --verify <TX_HASH> <PATH_TO_PROOF>
```

like:

```bash
./tokamak-cli --verify 0x3b8c38f1e41f31966d344a5efa3fa95d5df931bbf5bd0de1bf3384cdc1a95e52 ./.your_proof
```

but it did not work.

The following command worked instead:

```bash
./tokamak-cli --verify ./.your_proof
```



## Related Issue
<!-- Please link to the issue here -->
Closes #

## Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🔥 Breaking Change
- [ ] 🌟 New Feature
- [ ] 🐛 Bug Fix
- [O] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🔧 Code Refactoring
- [ ] 📈 Performance Improvements
- [ ] ✅ Test
- [O] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Testing
<!-- Please describe the tests you ran -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests