### PR TITLE
Removed input argument 'txNonce' to the EDDSA sign function that had …

### DIFF
--- a/packages/frontend/synthesizer/src/TokamakL2JS/tx/TokamakL2Tx.ts
+++ b/packages/frontend/synthesizer/src/TokamakL2JS/tx/TokamakL2Tx.ts
@@ -144,20 +144,20 @@ export class TokamakL2Tx extends LegacyTx implements TransactionInterface<typeof
             throw new Error('EDDSA private key must be in JubJub scalar field')
         }
         const msg = this.getMessageToSign()
-        const sig: {randomizer: EdwardsPoint, signature: bigint} = eddsaSign(sk, msg, bigIntToBytes(this.nonce))
+        const sig: {R: EdwardsPoint, S: bigint} = eddsaSign(sk, msg)
 
         const publicKey = jubjub.Point.BASE.multiply(sk)
         if (!publicKey.equals(jubjub.Point.fromBytes(this.senderPubKeyUnsafe))) {
             throw new Error("The public key initialized is not derived from the input private key")
         }
-        if (!eddsaVerify(msg, publicKey, sig.randomizer, sig.signature)) {
+        if (!eddsaVerify(msg, publicKey, sig.R, sig.S)) {
             throw new Error('Tried to sign but verification failure')
         }
 
         return this.addSignature(
             27n,
-            bytesToBigInt(sig.randomizer.toBytes()),
-            sig.signature
+            bytesToBigInt(sig.R.toBytes()),
+            sig.S
         )
     }
 }


### PR DESCRIPTION
## Description
EDDSA sign function no more takes as additional input entropy 'txNonce'. So, each EDDSA signature is uniquely determined by a message.

## Related Issue
<!-- Please link to the issue here -->
Closes #

## Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🔥 Breaking Change
- [ ] 🌟 New Feature
- [ O] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🔧 Code Refactoring
- [ ] 📈 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Testing
<!-- Please describe the tests you ran -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ O] Manual Tests