### PR TITLE
Resolved compat errors with tokamak-zkp-channel-manager

### DIFF
--- a/packages/frontend/synthesizer/examples/L2StateChannel/utils/mpt-key-util.ts
+++ b/packages/frontend/synthesizer/examples/L2StateChannel/utils/mpt-key-util.ts
@@ -7,7 +7,7 @@
 
 import { utf8ToBytes, setLengthLeft, bytesToBigInt, bigIntToBytes, bytesToHex } from '@ethereumjs/util';
 import { jubjub } from '@noble/curves/misc';
-import { fromEdwardsToAddress, getUserStorageKey } from '../../../src/TokamakL2JS/utils/index.ts';
+import { fromEdwardsToAddress, getUserStorageKey } from '../../../src/TokamakL2JS/utils/index';
 import { ethers } from 'ethers';
 
 /**

--- a/packages/frontend/synthesizer/package-lock.json
+++ b/packages/frontend/synthesizer/package-lock.json
@@ -28,7 +28,6 @@
         "debug": "^4.3.3",
         "dotenv": "^17.2.0",
         "ethereum-cryptography": "^3.0.0",
-        "ethers": "^6.14.3",
         "eventemitter3": "^5.0.1",
         "poseidon-bls12381": "^1.0.2",
         "verkle-cryptography-wasm": "^0.4.8",
@@ -51,6 +50,7 @@
         "babel-loader": "^10.0.0",
         "benchmark": "^2.1.4",
         "esbuild": "^0.25.8",
+        "ethers": "^6.14.3",
         "level": "^8.0.0",
         "mcl-wasm": "^1.5.0",
         "memory-level": "^1.0.0",
@@ -71,12 +71,21 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "ethers": "^6.14.3"
+      },
+      "peerDependenciesMeta": {
+        "ethers": {
+          "optional": false
+        }
       }
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -3463,7 +3472,8 @@
     "node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -6277,6 +6287,7 @@
       "version": "6.14.3",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.14.3.tgz",
       "integrity": "sha512-qq7ft/oCJohoTcsNPFaXSQUm457MA5iWqkf1Mb11ujONdg7jBI6sAOrHaTi3j0CBqIGFSCeR/RMc+qwRRub7IA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6305,6 +6316,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dev": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -6316,6 +6328,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
       "engines": {
         "node": ">= 16"
       },
@@ -6327,6 +6340,7 @@
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -11347,7 +11361,8 @@
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -11454,6 +11469,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -13684,6 +13700,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/packages/frontend/synthesizer/package.json
+++ b/packages/frontend/synthesizer/package.json
@@ -97,11 +97,16 @@
     "debug": "^4.3.3",
     "dotenv": "^17.2.0",
     "ethereum-cryptography": "^3.0.0",
-    "ethers": "^6.14.3",
     "eventemitter3": "^5.0.1",
     "poseidon-bls12381": "^1.0.2",
     "verkle-cryptography-wasm": "^0.4.8",
     "vitest": "^2.1.8"
+  },
+  "peerDependencies": {
+    "ethers": "^6.14.3"
+  },
+  "peerDependenciesMeta": {
+    "ethers": { "optional": false }
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",
@@ -133,7 +138,8 @@
     "ts-loader": "^9.5.2",
     "typescript": "^4.7.2",
     "webpack": "^5.101.0",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "ethers": "^6.14.3"
   },
   "engines": {
     "node": ">=18"

--- a/packages/frontend/synthesizer/src/TokamakL2JS/crypto/index.ts
+++ b/packages/frontend/synthesizer/src/TokamakL2JS/crypto/index.ts
@@ -3,9 +3,9 @@ import { DST_NONCE } from "../../synthesizer/params/index.ts";
 import { bigIntToBytes, bytesToBigInt, concatBytes, setLengthLeft } from "@ethereumjs/util";
 import { EdwardsPoint } from "@noble/curves/abstract/edwards";
 import { batchBigIntTo32BytesEach } from "../utils/index.ts";
-import { POSEIDON_INPUTS } from "src/interface/qapCompiler/importedConstants.ts";
-import { poseidon_raw } from "src/interface/qapCompiler/configuredTypes.ts";
-import { ArithmeticOperations } from "src/synthesizer/dataStructure/arithmeticOperations.ts";
+import { POSEIDON_INPUTS } from "../../interface/qapCompiler/importedConstants.ts";
+import { poseidon_raw } from "../../interface/qapCompiler/configuredTypes.ts";
+import { ArithmeticOperations } from "../../synthesizer/dataStructure/arithmeticOperations.ts";
 
 // To replace KECCAK256 with poseidon4. Example: 
 // const common = new Common({ chain: Mainnet, customCrypto: { keccak256: poseidon } })

--- a/packages/frontend/synthesizer/src/synthesizer/dataStructure/arithmeticOperations.ts
+++ b/packages/frontend/synthesizer/src/synthesizer/dataStructure/arithmeticOperations.ts
@@ -1,8 +1,8 @@
 import { jubjub } from "@noble/curves/misc"
 import { poseidon4 } from "poseidon-bls12381"
-import { poseidon_raw } from "src/interface/qapCompiler/configuredTypes.ts"
-import { ARITH_EXP_BATCH_SIZE, JUBJUB_EXP_BATCH_SIZE, POSEIDON_INPUTS } from "src/interface/qapCompiler/importedConstants.ts"
-import { DEFAULT_SOURCE_BIT_SIZE} from "src/synthesizer/params/index.ts"
+import { poseidon_raw } from "../../interface/qapCompiler/configuredTypes.ts"
+import { ARITH_EXP_BATCH_SIZE, JUBJUB_EXP_BATCH_SIZE, POSEIDON_INPUTS } from "../../interface/qapCompiler/importedConstants.ts"
+import { DEFAULT_SOURCE_BIT_SIZE} from "../../synthesizer/params/index.ts"
 
 const convertToSigned = (value: bigint): bigint => {
   const SIGN_BIT = 1n << 255n


### PR DESCRIPTION
## Description
Resolved compatibility errors with the repository 'Tokamak-zkp-channel-manager', which uses 'ale-154-1' branch as a submodule.

- Removed some conventions such as import { ... } from "src/...", which relies on tsconfig.json.
- Applied a safer way for resolving a relative path (See `getBaseURL()` in "packages/frontend/synthesizer/src/interface/qapCompiler/utils.ts".
- Changed the type of dependency for 'ethers' package (See  packages/frontend/synthesizer/package.json)

Modified src files:
modified:   packages/frontend/synthesizer/examples/L2StateChannel/utils/mpt-key-util.ts
modified:   packages/frontend/synthesizer/package.json
modified:   packages/frontend/synthesizer/src/TokamakL2JS/crypto/index.ts
modified:   packages/frontend/synthesizer/src/interface/qapCompiler/utils.ts
modified:   packages/frontend/synthesizer/src/synthesizer/dataStructure/arithmeticOperations.ts

## Related Issue
<!-- Please link to the issue here -->
Closes #

## Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🔥 Breaking Change
- [ ] 🌟 New Feature
- [ O] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ O] 🔧 Code Refactoring
- [ ] 📈 Performance Improvements
- [ ] ✅ Test
- [ O] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Testing
<!-- Please describe the tests you ran -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ O] Manual Tests