### PR TITLE
Changed the format of L2 private key to be less than Jubjub scalar field

### DIFF
--- a/packages/frontend/synthesizer/src/TokamakL2JS/utils/web.ts
+++ b/packages/frontend/synthesizer/src/TokamakL2JS/utils/web.ts
@@ -1,7 +1,7 @@
 import { utf8ToBytes } from "ethereum-cryptography/utils";
 import { poseidon } from "../crypto/index.ts";
 import { jubjub } from "@noble/curves/misc.js";
-import { bytesToBigInt, bytesToHex } from "@ethereumjs/util";
+import { bigIntToBytes, bytesToBigInt, bytesToHex, setLengthLeft } from "@ethereumjs/util";
 import { fromEdwardsToAddress, getUserStorageKey } from "./utils.ts";
 
 export const L2_PRV_KEY_MESSAGE='Tokamak-Private-App-Channel-'
@@ -21,8 +21,9 @@ export const deriveSignatureFromMetaMask = async (signMessageAsync: (args: { mes
 };
 
 export const deriveL2KeysFromSignature = (signature: `0x${string}`):  L2KeyPair => {
-  const privateKey = jubjub.utils.randomPrivateKey(poseidon(utf8ToBytes(signature)));
-  const publicKey = jubjub.Point.BASE.multiply(bytesToBigInt(privateKey) % jubjub.Point.Fn.ORDER).toBytes();
+  const rngStringRaw = jubjub.utils.randomPrivateKey(poseidon(utf8ToBytes(signature)));
+  const privateKey = setLengthLeft(bigIntToBytes(bytesToBigInt(rngStringRaw) % jubjub.Point.Fn.ORDER), 32);
+  const publicKey = jubjub.Point.BASE.multiply(bytesToBigInt(privateKey)).toBytes();
   return {privateKey, publicKey};
 };
 


### PR DESCRIPTION
## Description
Bugfix: Changed the format of L2 private key to be less than Jubjub scalar field
## Related Issue
<!-- Please link to the issue here -->
Closes #

## Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🔥 Breaking Change
- [ ] 🌟 New Feature
- [ O] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🔧 Code Refactoring
- [ ] 📈 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Testing
<!-- Please describe the tests you ran -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ O] Manual Tests