### PR TITLE
fix(synthesizer): Restore poseidon hash for empty merkle tree leaves

### DIFF
--- a/packages/frontend/synthesizer/src/TokamakL2JS/stateManager/TokamakL2StateManager.ts
+++ b/packages/frontend/synthesizer/src/TokamakL2JS/stateManager/TokamakL2StateManager.ts
@@ -65,8 +65,8 @@ export class TokamakL2StateManager extends MerkleStateManager implements StateMa
         const leaves = new Array<bigint>(MAX_MT_LEAVES)
         for (var index = 0; index < MAX_MT_LEAVES; index++) {
             const key = this.registeredKeys![index]
-            if (key === undefined ) {
-                leaves[index] = 0n
+            if (key === undefined) {
+                leaves[index] = poseidon_raw([0n, 0n])
             } else {
                 const val = await this.getStorage(contractAddress, key)
                 leaves[index] = poseidon_raw([bytesToBigInt(key), bytesToBigInt(val)])


### PR DESCRIPTION
## Description
Fixed merkle tree root mismatch between synthesizer and on-chain state by restoring the correct empty leaf hash computation.

Changed empty leaf computation back to `poseidon_raw([0n, 0n])` in `TokamakL2StateManager.convertLeavesIntoMerkleTreeLeaves()` to match the on-chain merkle tree construction.

## Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🔥 Breaking Change
- [ ] 🌟 New Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🔧 Code Refactoring
- [ ] 📈 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Testing
<!-- Please describe the tests you ran -->
- [ ] Unit Tests
- [x] Integration Tests
- [x] Manual Tests