### PR TITLE
feat(ci): Update CI/CD for L2 examples testing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -160,6 +160,14 @@ jobs:
           chmod +x dist/bin/* 2>/dev/null || true
           chmod +x dist/*.sh 2>/dev/null || true
 
+      - name: Setup synthesizer environment
+        env:
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY || 'test_api_key_placeholder' }}
+        run: |
+          # Create .env file for synthesizer (not included in artifact due to .gitignore)
+          echo "RPC_URL='https://eth-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY'" > packages/frontend/synthesizer/.env
+          echo "✅ Synthesizer .env configured"
+
       - name: Run L2TONTransfer synthesizer
         run: |
           echo "🧪 Running L2TONTransfer synthesizer..."

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,28 +2,20 @@ name: Test, Build & Release
 
 on:
   push:
-    branches: [main, dev, ale-153] # Execute when pushing to main, dev, or ale-153 branch
+    branches: [main, dev, ale-ci] # Execute when pushing to main, dev, or ale-ci branch
   pull_request:
-    branches: [main, dev, ale-153] # Execute on PR creation and updates to main, dev, or ale-153 branch
+    branches: [main, dev, ale-ci] # Execute on PR creation and updates
   workflow_dispatch: # Manual execution allowed
 
 jobs:
-  proof-generation-test:
-    name: Proof Generation Test
+  # ============================================================================
+  # Build & Setup - Build binaries once and share across test jobs
+  # ============================================================================
+  build-and-setup:
+    name: Build & Setup
     runs-on: ubuntu-22.04
     timeout-minutes: 45
-    # Execute on push to main or on any PR to main (for validation)
     if: github.event_name == 'push' || github.event_name == 'pull_request'
-
-    strategy:
-      matrix:
-        # Execute TON Transfer test only - using same tx as L2TONTransfer example
-        test_case:
-          - name: 'ton-transfer'
-            tx_hash: '0xa0090893a2d5f79b67cebcb65eac3efc92820ec09dc4ad9fe2bc29bbdcad2e41'
-            description: 'TON Transfer'
-
-      fail-fast: false # Continue other tests even if one fails
 
     steps:
       - name: Checkout code
@@ -37,16 +29,25 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # Ubuntu에서는 apt 사용
           sudo apt-get update
           sudo apt-get install -y dos2unix cmake build-essential
 
       - name: Install Rust and Cargo
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/backend/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Install circom
         run: |
-          # Install circom 2.2.2 for Linux
           wget https://github.com/iden3/circom/releases/download/v2.2.2/circom-linux-amd64
           chmod +x circom-linux-amd64
           sudo mv circom-linux-amd64 /usr/local/bin/circom
@@ -57,15 +58,12 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Verify Bun installation
+      - name: Make scripts executable
         run: |
-          bun --version
-          echo "✅ Bun is ready"
+          chmod +x ./tokamak-cli
+          chmod +x ./scripts/tokamak-cli-core
 
-      - name: Make tokamak-cli executable
-        run: chmod +x ./scripts/tokamak-cli-core
-
-      - name: Setup environment
+      - name: Build and setup environment
         env:
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY || 'test_api_key_placeholder' }}
         run: |
@@ -74,68 +72,271 @@ jobs:
           find . -name "*.sh" -exec chmod +x {} \;
           find . -name "*.sh" -exec dos2unix {} \; 2>/dev/null || true
 
-          # Use npm install to resolve dependency issues
-          echo "🔧 Installing dependencies with npm install instead of npm ci..."
+          # Install dependencies
+          echo "🔧 Installing frontend dependencies..."
           cd packages/frontend/qap-compiler && npm install --legacy-peer-deps
           cd ../synthesizer && npm install --legacy-peer-deps
           cd ../../..
 
-          # Install tsx globally (required for synthesizer)
+          # Install tsx globally
           npm install -g tsx
-          ./scripts/tokamak-cli-core --install "$ALCHEMY_API_KEY"
 
-          # Export RPC_URL for subsequent steps
-          echo "RPC_URL=https://eth-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY" >> $GITHUB_ENV
+          # Run install step (this builds all binaries)
+          echo "🔧 Running tokamak-cli --install (building binaries)..."
+          ./tokamak-cli --install "$ALCHEMY_API_KEY"
 
-      - name: Generate proof for ${{ matrix.test_case.name }}
-        env:
-          RPC_URL: ${{ env.RPC_URL }}
-        run: |
-          echo "🧪 Testing: ${{ matrix.test_case.description }}"
-          echo "📋 TX Hash: ${{ matrix.test_case.tx_hash }}"
-
-          # Attempt proof generation
-          ./scripts/tokamak-cli-core --prove "${{ matrix.test_case.tx_hash }}" "./proof_${{ matrix.test_case.name }}"
-
-      - name: Validate proof artifacts
-        run: |
-          # Verify that required files were generated
-          test -f "./proof_${{ matrix.test_case.name }}/transaction_hash.txt"
-          test -f "./proof_${{ matrix.test_case.name }}/proof.json"
-
-          # Verify that transaction hash was stored correctly
-          stored_hash=$(cat "./proof_${{ matrix.test_case.name }}/transaction_hash.txt")
-          if [[ "$stored_hash" != "${{ matrix.test_case.tx_hash }}" ]]; then
-            echo "❌ Transaction hash mismatch!"
-            echo "Expected: ${{ matrix.test_case.tx_hash }}"
-            echo "Got: $stored_hash"
-            exit 1
-          fi
-
-          echo "✅ Proof validation passed for ${{ matrix.test_case.name }}"
-
-      - name: Upload proof artifacts
-        if: always() # Upload artifacts even on failure
+      - name: Upload built dist folder
         uses: actions/upload-artifact@v4
         with:
-          name: proof-artifacts-${{ matrix.test_case.name }}-${{ github.run_number }}
-          path: ./proof_${{ matrix.test_case.name }}/
-          retention-days: 7
+          name: built-dist
+          path: dist/
+          retention-days: 1
 
       - name: Upload setup files for reuse
-        if: success() # Upload only on success
         uses: actions/upload-artifact@v4
         with:
           name: setup-files
-          path: dist/linux22/resource/setup/output/
+          path: dist/resource/setup/output/
           retention-days: 7
 
+      - name: Upload qap-compiler for tests
+        uses: actions/upload-artifact@v4
+        with:
+          name: qap-compiler
+          path: packages/frontend/qap-compiler/
+          retention-days: 1
+
+      - name: Upload synthesizer for tests
+        uses: actions/upload-artifact@v4
+        with:
+          name: synthesizer
+          path: packages/frontend/synthesizer/
+          retention-days: 1
+
+  # ============================================================================
+  # L2TONTransfer Test - Uses pre-built binaries
+  # ============================================================================
+  l2-ton-transfer-test:
+    name: L2 TON Transfer Test
+    runs-on: ubuntu-22.04
+    needs: build-and-setup
+    timeout-minutes: 30
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install tsx globally
+        run: npm install -g tsx
+
+      - name: Download built dist
+        uses: actions/download-artifact@v4
+        with:
+          name: built-dist
+          path: dist/
+
+      - name: Download qap-compiler
+        uses: actions/download-artifact@v4
+        with:
+          name: qap-compiler
+          path: packages/frontend/qap-compiler/
+
+      - name: Download synthesizer
+        uses: actions/download-artifact@v4
+        with:
+          name: synthesizer
+          path: packages/frontend/synthesizer/
+
+      - name: Make binaries executable
+        run: |
+          chmod +x ./tokamak-cli
+          chmod +x ./scripts/tokamak-cli-core
+          chmod +x dist/bin/* 2>/dev/null || true
+          chmod +x dist/*.sh 2>/dev/null || true
+
+      - name: Run L2TONTransfer synthesizer
+        run: |
+          echo "🧪 Running L2TONTransfer synthesizer..."
+          echo "📋 Config: packages/frontend/synthesizer/examples/L2TONTransfer/input.json"
+          ./tokamak-cli --synthesize packages/frontend/synthesizer/examples/L2TONTransfer/input.json
+
+      - name: Run preprocess
+        run: |
+          echo "⚙️ Running preprocess..."
+          ./tokamak-cli --preprocess
+
+      - name: Run prove
+        run: |
+          echo "🔐 Running prove..."
+          ./tokamak-cli --prove
+
+      - name: Run verify
+        run: |
+          echo "✅ Running verify..."
+          ./tokamak-cli --verify
+
+      - name: Validate proof artifacts
+        run: |
+          echo "🔍 Validating proof artifacts..."
+          
+          if [ -f "dist/resource/prove/output/proof.json" ]; then
+            echo "✅ proof.json exists"
+          else
+            echo "❌ proof.json not found"
+            exit 1
+          fi
+          
+          if [ -f "dist/resource/preprocess/output/preprocess.json" ]; then
+            echo "✅ preprocess.json exists"
+          else
+            echo "❌ preprocess.json not found"
+            exit 1
+          fi
+          
+          echo "✅ L2TONTransfer test passed!"
+
+      - name: Upload L2TONTransfer artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: l2-ton-transfer-artifacts-${{ github.run_number }}
+          path: |
+            dist/resource/prove/output/
+            dist/resource/preprocess/output/
+            dist/resource/synthesizer/output/
+          retention-days: 7
+
+  # ============================================================================
+  # L2StateChannel Test - Uses pre-built binaries
+  # ============================================================================
+  l2-state-channel-test:
+    name: L2 State Channel Test
+    runs-on: ubuntu-22.04
+    needs: build-and-setup
+    timeout-minutes: 30
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install tsx globally
+        run: npm install -g tsx
+
+      - name: Download built dist
+        uses: actions/download-artifact@v4
+        with:
+          name: built-dist
+          path: dist/
+
+      - name: Download qap-compiler
+        uses: actions/download-artifact@v4
+        with:
+          name: qap-compiler
+          path: packages/frontend/qap-compiler/
+
+      - name: Download synthesizer
+        uses: actions/download-artifact@v4
+        with:
+          name: synthesizer
+          path: packages/frontend/synthesizer/
+
+      - name: Make binaries executable
+        run: |
+          chmod +x ./tokamak-cli
+          chmod +x ./scripts/tokamak-cli-core
+          chmod +x dist/bin/* 2>/dev/null || true
+          chmod +x dist/*.sh 2>/dev/null || true
+
+      - name: Setup L2StateChannel environment
+        env:
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY || 'test_api_key_placeholder' }}
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL || '' }}
+        run: |
+          # Setup L2StateChannel .env for Sepolia
+          if [ -n "$SEPOLIA_RPC_URL" ]; then
+            echo "SEPOLIA_RPC_URL='$SEPOLIA_RPC_URL'" > packages/frontend/synthesizer/examples/L2StateChannel/.env
+            echo "DEV_MODE=true" >> packages/frontend/synthesizer/examples/L2StateChannel/.env
+            echo "✅ L2StateChannel .env configured with Sepolia RPC"
+          else
+            echo "RPC_URL='https://eth-sepolia.g.alchemy.com/v2/$ALCHEMY_API_KEY'" > packages/frontend/synthesizer/examples/L2StateChannel/.env
+            echo "SEPOLIA_RPC_URL='https://eth-sepolia.g.alchemy.com/v2/$ALCHEMY_API_KEY'" >> packages/frontend/synthesizer/examples/L2StateChannel/.env
+            echo "DEV_MODE=true" >> packages/frontend/synthesizer/examples/L2StateChannel/.env
+            echo "✅ L2StateChannel .env configured with Alchemy Sepolia"
+          fi
+
+      - name: Run L2StateChannel CI test (synthesize)
+        working-directory: packages/frontend/synthesizer
+        run: |
+          echo "🧪 Running L2StateChannel CI test..."
+          npx tsx examples/L2StateChannel/index.ts --ci
+
+      - name: Copy synthesizer outputs to dist
+        run: |
+          echo "📁 Copying synthesizer outputs to dist..."
+          mkdir -p dist/resource/synthesizer/output
+          cp -r packages/frontend/synthesizer/examples/L2StateChannel/output/ci-test/* dist/resource/synthesizer/output/
+          ls -la dist/resource/synthesizer/output/
+
+      - name: Run preprocess
+        run: |
+          echo "⚙️ Running preprocess..."
+          ./tokamak-cli --preprocess
+
+      - name: Run prove
+        run: |
+          echo "🔐 Running prove..."
+          ./tokamak-cli --prove
+
+      - name: Run verify
+        run: |
+          echo "✅ Running verify..."
+          ./tokamak-cli --verify
+
+      - name: Validate proof artifacts
+        run: |
+          echo "🔍 Validating proof artifacts..."
+          
+          if [ -f "dist/resource/prove/output/proof.json" ]; then
+            echo "✅ proof.json exists"
+          else
+            echo "❌ proof.json not found"
+            exit 1
+          fi
+          
+          echo "✅ L2StateChannel test passed!"
+
+      - name: Upload L2StateChannel artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: l2-state-channel-artifacts-${{ github.run_number }}
+          path: |
+            packages/frontend/synthesizer/examples/L2StateChannel/output/ci-test/
+            dist/resource/prove/output/
+            dist/resource/preprocess/output/
+          retention-days: 7
+
+  # ============================================================================
+  # Build macOS Binary
+  # ============================================================================
   build-macos:
     name: Build macOS Binary
     runs-on: macos-latest
-    needs: proof-generation-test
+    needs: [l2-ton-transfer-test, l2-state-channel-test]
     timeout-minutes: 60
-    # Execute only for main branch (push/PR), skip dev and ale-153 branches
+    # Execute only for main branch (push/PR)
     if: (github.event_name == 'push' || github.event_name == 'pull_request') && (github.ref == 'refs/heads/main' || github.base_ref == 'main')
 
     steps:
@@ -147,7 +348,6 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # Install macOS dependencies
           brew install dos2unix
 
       - name: Cache Rust dependencies
@@ -166,7 +366,7 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Download setup files from proof test
+      - name: Download setup files from build
         uses: actions/download-artifact@v4
         with:
           name: setup-files
@@ -185,12 +385,15 @@ jobs:
           path: tokamak-zk-evm-macOS.zip
           retention-days: 30
 
+  # ============================================================================
+  # Build Linux Binary
+  # ============================================================================
   build-linux:
     name: Build Linux Binary
-    runs-on: ubuntu-22.04 # Specify Linux 22 version
-    needs: proof-generation-test # Execute after proof test passes
+    runs-on: ubuntu-22.04
+    needs: [l2-ton-transfer-test, l2-state-channel-test]
     timeout-minutes: 60
-    # Execute only for main branch (push/PR), skip dev and ale-153 branches
+    # Execute only for main branch (push/PR)
     if: (github.event_name == 'push' || github.event_name == 'pull_request') && (github.ref == 'refs/heads/main' || github.base_ref == 'main')
 
     steps:
@@ -202,15 +405,8 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # Install Ubuntu dependencies
           sudo apt-get update
           sudo apt-get install -y dos2unix build-essential curl cmake
-
-          # Verify installed tools
-          gcc --version
-          g++ --version
-          cmake --version
-          dos2unix --version
 
       - name: Cache Rust dependencies
         uses: actions/cache@v4
@@ -228,12 +424,7 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Verify Bun installation
-        run: |
-          bun --version
-          echo "✅ Bun is ready"
-
-      - name: Download setup files from proof test
+      - name: Download setup files from build
         uses: actions/download-artifact@v4
         with:
           name: setup-files
@@ -245,29 +436,13 @@ jobs:
           chmod +x scripts/packaging.sh
           ./scripts/packaging.sh --linux --bun --no-setup
 
-      - name: Download setup files from proof test
-        uses: actions/download-artifact@v4
-        with:
-          name: setup-files
-          path: ./setup-for-archive/
-
       - name: Create setup files archive
         run: |
-          echo "📦 Creating setup files archive from proof test results..."
-
-          # Check if setup files exist
-          if [ -d "./setup-for-archive" ] && [ "$(ls -A ./setup-for-archive 2>/dev/null)" ]; then
-            echo "✅ Found setup files from proof test"
-            ls -la ./setup-for-archive/
-            
-            # Create archive from actual setup files
-            tar -C ./setup-for-archive -c . | gzip -9 > tokamak-zk-evm-setup-files.tar.gz
-            
-            echo "📊 Setup files archive created:"
-            ls -lh tokamak-zk-evm-setup-files.tar.gz
+          echo "📦 Creating setup files archive..."
+          if [ -d "./prebuilt-setup" ] && [ "$(ls -A ./prebuilt-setup 2>/dev/null)" ]; then
+            tar -C ./prebuilt-setup -c . | gzip -9 > tokamak-zk-evm-setup-files.tar.gz
+            echo "✅ Setup files archive created"
           else
-            echo "❌ No setup files found from proof test"
-            echo "Creating empty archive as fallback..."
             mkdir -p empty-setup
             echo "No setup files available" > empty-setup/README.txt
             tar -C empty-setup -c . | gzip -9 > tokamak-zk-evm-setup-files.tar.gz
@@ -288,34 +463,33 @@ jobs:
           path: tokamak-zk-evm-setup-files.tar.gz
           retention-days: 30
 
+  # ============================================================================
+  # Create GitHub Release
+  # ============================================================================
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-22.04
-    needs: [proof-generation-test, build-macos, build-linux]
-    # Execute only when all tests and builds succeed, and only on push to main branch
+    needs: [l2-ton-transfer-test, l2-state-channel-test, build-macos, build-linux]
     if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch full history (needed for tag information)
+          fetch-depth: 0
 
       - name: Generate version tag
         id: version
         run: |
-          # Generate different version tags based on branch
           DATE=$(date +%Y.%m.%d)
           SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
           BRANCH_NAME="${{ github.ref_name }}"
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
-            # Main branch: Official release (v2024.01.15)
             VERSION="v${DATE}"
             IS_PRERELEASE="false"
             RELEASE_TYPE="Release"
           else
-            # Test branch: Test release (test-ale-150-v2024.01.15-abc1234)
             VERSION="test-${BRANCH_NAME}-v${DATE}-${SHORT_SHA}"
             IS_PRERELEASE="true"
             RELEASE_TYPE="Test Release"
@@ -328,92 +502,57 @@ jobs:
           echo "is_prerelease=${IS_PRERELEASE}" >> $GITHUB_OUTPUT
           echo "release_type=${RELEASE_TYPE}" >> $GITHUB_OUTPUT
 
-          echo "🏷️ Generated version: ${VERSION}"
-          echo "🌿 Branch: ${BRANCH_NAME}"
-          echo "🏷️ Release type: ${RELEASE_TYPE}"
-
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: ./artifacts
 
-      - name: Debug artifacts
-        run: |
-          echo "🔍 Checking downloaded artifacts..."
-          ls -la ./artifacts/
-          echo ""
-          echo "🔍 Expected artifacts:"
-          echo "- tokamak-zk-evm-macos"
-          echo "- tokamak-zk-evm-linux22"
-          echo "- tokamak-zk-evm-setup-files"
-          echo ""
-          echo "🔍 Actual artifacts found:"
-          find ./artifacts -name "*.zip" -o -name "*.tar.gz" | head -10
-
       - name: Prepare release assets
         run: |
           mkdir -p ./release-assets
-
-          # Track failed artifacts
           MISSING_ASSETS=()
 
-          # Copy macOS binary
-          if [ -d "./artifacts/tokamak-zk-evm-macos" ] && [ -f "./artifacts/tokamak-zk-evm-macos/tokamak-zk-evm-macOS.zip" ]; then
+          if [ -f "./artifacts/tokamak-zk-evm-macos/tokamak-zk-evm-macOS.zip" ]; then
             cp "./artifacts/tokamak-zk-evm-macos/tokamak-zk-evm-macOS.zip" \
                "./release-assets/tokamak-zk-evm-${{ steps.version.outputs.version }}-macos.zip"
             echo "✅ macOS binary prepared"
           else
-            echo "❌ macOS binary not found"
             MISSING_ASSETS+=("macOS binary")
           fi
 
-          # Copy Linux binary
-          if [ -d "./artifacts/tokamak-zk-evm-linux22" ] && [ -f "./artifacts/tokamak-zk-evm-linux22/tokamak-zk-evm-linux22.tar.gz" ]; then
+          if [ -f "./artifacts/tokamak-zk-evm-linux22/tokamak-zk-evm-linux22.tar.gz" ]; then
             cp "./artifacts/tokamak-zk-evm-linux22/tokamak-zk-evm-linux22.tar.gz" \
                "./release-assets/tokamak-zk-evm-${{ steps.version.outputs.version }}-linux22.tar.gz"
             echo "✅ Linux binary prepared"
           else
-            echo "❌ Linux binary not found"
             MISSING_ASSETS+=("Linux binary")
           fi
 
-          # Copy setup files
-          if [ -d "./artifacts/tokamak-zk-evm-setup-files" ] && [ -f "./artifacts/tokamak-zk-evm-setup-files/tokamak-zk-evm-setup-files.tar.gz" ]; then
+          if [ -f "./artifacts/tokamak-zk-evm-setup-files/tokamak-zk-evm-setup-files.tar.gz" ]; then
             cp "./artifacts/tokamak-zk-evm-setup-files/tokamak-zk-evm-setup-files.tar.gz" \
                "./release-assets/tokamak-zk-evm-${{ steps.version.outputs.version }}-setup-files.tar.gz"
             echo "✅ Setup files prepared"
           else
-            echo "❌ Setup files not found"
             MISSING_ASSETS+=("Setup files")
           fi
 
-          # Fail if there are missing artifacts
           if [ ${#MISSING_ASSETS[@]} -gt 0 ]; then
-            echo ""
             echo "💥 Missing required assets:"
             printf '%s\n' "${MISSING_ASSETS[@]}"
-            echo ""
-            echo "🔍 This usually means one of the build jobs failed."
-            echo "   Check the build job logs above for errors."
             exit 1
           fi
 
-          echo "📦 All release assets prepared:"
           ls -lh ./release-assets/
 
       - name: Generate release notes
-        id: release_notes
         run: |
-          # Generate release notes from recent commits
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-
           if [ -n "$LAST_TAG" ]; then
             COMMITS=$(git log ${LAST_TAG}..HEAD --oneline --no-merges | head -20)
           else
             COMMITS=$(git log --oneline --no-merges | head -20)
           fi
 
-          # Write release notes
           cat > release_notes.md << EOF
           ## 🚀 Tokamak-zk-EVM ${{ steps.version.outputs.release_type }} ${{ steps.version.outputs.version }}
 
@@ -427,40 +566,10 @@ jobs:
           - **Linux (Ubuntu 22.04)**: \`tokamak-zk-evm-${{ steps.version.outputs.version }}-linux22.tar.gz\`
           - **Setup Files** (Optional): \`tokamak-zk-evm-${{ steps.version.outputs.version }}-setup-files.tar.gz\`
 
-          EOF
-
-          # Additional notice for test branches
-          if [[ "${{ steps.version.outputs.branch }}" != "main" ]]; then
-            cat >> release_notes.md << EOF
-
-          > ⚠️ **This is a test release** from branch \`${{ steps.version.outputs.branch }}\`  
-          > This release is for testing purposes only and should not be used in production.
-
-          EOF
-          fi
-
-          cat >> release_notes.md << EOF
-
           ### ✅ Quality Assurance
 
-          - **Proof Generation Test**: Passed ✅
-          - **Transaction**: TON Transfer (0x6c7903e420c5efb27639f5186a7474ef2137f12c786a90b4efdcb5d88dfdb002)
-          - **Validation**: All proof artifacts verified
-
-          ### 🔧 What's Included
-
-          **Main Binaries:**
-          - \`trusted-setup\` - Trusted setup ceremony binary
-          - \`preprocess\` - Preprocessing binary  
-          - \`prove\` - Proof generation binary
-          - \`verify\` - Proof verification binary
-          - \`synthesizer\` - Transaction synthesizer binary
-          - Required libraries and resources
-
-          **Setup Files (Optional Download):**
-          - Pre-generated trusted setup parameters
-          - Skip the time-consuming trusted setup process
-          - Extract to \`resource/setup/output/\` in your installation
+          - **L2 TON Transfer Test**: Passed ✅
+          - **L2 State Channel Test**: Passed ✅
 
           ### 📋 Recent Changes
 
@@ -474,36 +583,13 @@ jobs:
             echo "- Initial release" >> release_notes.md
           fi
 
-          cat >> release_notes.md << EOF
-
-          ### 🛠️ Installation
-
-          1. Download the appropriate binary for your platform
-          2. Extract the archive
-          3. Run the setup script: \`./1_run-trusted-setup.sh\`
-          4. Use the binaries as needed
-
-          ### ⚠️ Requirements
-
-          - **macOS**: macOS 10.15+ (Catalina or later)
-          - **Linux**: Ubuntu 22.04 or compatible distribution
-
-          ---
-
-          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${LAST_TAG}...${{ steps.version.outputs.version }}
-          EOF
-
-          echo "Generated release notes:"
-          cat release_notes.md
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: 'Tokamak-zk-EVM ${{ steps.version.outputs.release_type }} ${{ steps.version.outputs.version }}'
           body_path: release_notes.md
-          files: |
-            ./release-assets/*
+          files: ./release-assets/*
           draft: false
           prerelease: ${{ steps.version.outputs.is_prerelease }}
         env:
@@ -511,17 +597,6 @@ jobs:
 
       - name: Update build summary
         run: |
-          echo "## 🎉 ${{ steps.version.outputs.release_type }} Created Successfully!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📋 Release Information" >> $GITHUB_STEP_SUMMARY
-          echo "- **Type**: ${{ steps.version.outputs.release_type }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branch**: ${{ steps.version.outputs.branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "## 🎉 Release Created!" >> $GITHUB_STEP_SUMMARY
           echo "- **Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Release URL**: https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 Available Downloads" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ **macOS Binary**: tokamak-zk-evm-${{ steps.version.outputs.version }}-macos.zip" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ **Linux Binary**: tokamak-zk-evm-${{ steps.version.outputs.version }}-linux22.tar.gz" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ **Setup Files**: tokamak-zk-evm-${{ steps.version.outputs.version }}-setup-files.tar.gz" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 **[View Release](https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version }})**" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL**: https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY

--- a/packages/frontend/synthesizer/package.json
+++ b/packages/frontend/synthesizer/package.json
@@ -75,6 +75,7 @@
     "test:single": "tsx examples/L2StateChannel/test-single-proof.ts",
     "test:onchain": "tsx examples/L2StateChannel/onchain-channel-simulation.ts",
     "test:binary-cli": "tsx examples/L2StateChannel/test-binary-cli.ts",
+    "test:ci-state-channel": "tsx examples/L2StateChannel/index.ts --ci",
     "tsc": "../../../config/monorepo-js//cli/ts-compile.sh"
   },
   "dependencies": {


### PR DESCRIPTION
## Description
Update CI/CD pipeline to test L2TONTransfer and L2StateChannel examples instead of Ethereum transaction-based testing.

## Changes
- Add CI mode (`--ci` flag) to L2StateChannel/index.ts for non-interactive testing
- Optimize CI workflow: build once, test in parallel
- Add `ale-ci` branch to CI triggers
- Add `test:ci-state-channel` npm script

## CI Structure
See the test run: https://github.com/tokamak-network/Tokamak-zk-EVM/actions/runs/20612029107

## Test Results
- ✅ L2 TON Transfer Test
- ✅ L2 State Channel Test

## Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🔥 Breaking Change
- [ ] 🌟 New Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🔧 Code Refactoring
- [ ] 📈 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Testing
<!-- Please describe the tests you ran -->
- [ ] Unit Tests
- [x] Integration Tests
- [x] Manual Tests