### PR TITLE
block hash starting at block number n-1

### DIFF
--- a/packages/frontend/synthesizer/src/synthesizer/handlers/bufferManager.ts
+++ b/packages/frontend/synthesizer/src/synthesizer/handlers/bufferManager.ts
@@ -165,7 +165,7 @@ export class BufferManager {
     this.addReservedVariableToBufferIn('SELFBALANCE', hexToBigInt(this.cachedOpts.blockInfo.selfBalance))
     this.addReservedVariableToBufferIn('BASEFEE', hexToBigInt(this.cachedOpts.blockInfo.baseFee))
     for (var i = 1; i <= NUMBER_OF_PREV_BLOCK_HASHES; i++) {
-      this.addReservedVariableToBufferIn(`BLOCKHASH_${i}` as ReservedVariable, hexToBigInt(this.cachedOpts.blockInfo.blockHashes[i-1]))
+      this.addReservedVariableToBufferIn(`BLOCKHASH_${i}` as ReservedVariable, hexToBigInt(this.cachedOpts.blockInfo.blockHashes[i]))
     }
 
     // Transaction inputs


### PR DESCRIPTION
## Description
Corrected block hash indexing in `bufferManager.ts:168` to start from block number `n-1` instead of `n`. Changed `blockHashes[i-1]` to `blockHashes[i]` so that `BLOCKHASH_1` now correctly references the previous block hash rather than the current block hash.

  This ensures the `a_pub_block` instance construction uses the proper block hash sequence for ZK proof generation.

## Related Issue
<!-- Please link to the issue here -->
Closes #

## Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🔥 Breaking Change
- [ ] 🌟 New Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🔧 Code Refactoring
- [ ] 📈 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Testing
<!-- Please describe the tests you ran -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests