### PR TITLE
feat: timing instrumentation and report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ target/
 Cargo.lock
 **/*.rs.bk
 **/output/
+!packages/backend/prove/output/
+packages/backend/prove/output/*
+!packages/backend/prove/output/timing.release.md
 
 # Node
 node_modules/

--- a/packages/backend/.vscode/launch.json
+++ b/packages/backend/.vscode/launch.json
@@ -176,6 +176,29 @@
       "sourceLanguages": ["rust"]
     },
     {
+      "name": "Test prove timing (timing feature)",
+      "type": "lldb",
+      "request": "launch",
+      "cargo": {
+        "args": ["test", "--release", "-p", "prove", "--features", "timing", "--test", "timing", "--", "--nocapture"],
+        "filter": { "name": "timing", "kind": "test" }
+      },
+      "program": "${cargo:program}",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "PROVE_QAP_PATH": "${workspaceFolder}/../frontend/qap-compiler/subcircuits/library",
+        "PROVE_SYNTHESIZER_PATH": "${workspaceFolder}/../frontend/synthesizer/outputs",
+        "PROVE_SETUP_PATH": "${workspaceFolder}/setup/trusted-setup/output",
+        "PROVE_OUT_PATH": "${workspaceFolder}/prove/output",
+        "TIMING_OUT": "${workspaceFolder}/prove/output/timing.release.json",
+        "DYLD_LIBRARY_PATH": "${workspaceFolder}/external-lib/mac/lib",
+        "LD_LIBRARY_PATH": "${workspaceFolder}/external-lib/mac/lib:${env:LD_LIBRARY_PATH}"
+      },
+      "postDebugTask": "timing:json-to-md",
+      "sourceLanguages": ["rust"]
+    },
+    {
       "name": "Debug verify (release)",
       "type": "lldb",
       "request": "launch",

--- a/packages/backend/.vscode/tasks.json
+++ b/packages/backend/.vscode/tasks.json
@@ -1,20 +1,19 @@
-// {
-//     "version": "2.0.0",
-//     "tasks": [
-//         {
-//             "label": "cargo build",
-//             "type": "shell",
-//             "command": "cargo",
-//             "args": [
-//                 "build",
-//                 "--release",
-//             ],
-//             "group": {
-//                 "kind": "build",
-//                 "isDefault": true
-//             },
-//             "problemMatcher": ["$rustc"],
-//             "detail": "Build Rust project for debugging"
-//         }
-//     ]
-// }
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "timing:json-to-md",
+      "type": "shell",
+      "command": "python3",
+      "args": [
+        "${workspaceFolder}/prove/scripts/timing_to_md.py",
+        "--input",
+        "${workspaceFolder}/prove/output/timing.release.json",
+        "--output",
+        "${workspaceFolder}/prove/output/timing.release.md"
+      ],
+      "problemMatcher": [],
+      "detail": "Convert timing JSON to Markdown report"
+    }
+  ]
+}

--- a/packages/backend/libs/src/iotools/mod.rs
+++ b/packages/backend/libs/src/iotools/mod.rs
@@ -1006,9 +1006,9 @@ pub fn read_R1CS_gen_uvwXY(
             &mut hex_cache_hits,
             &mut hex_cache_misses
         );
-        println!("    ⚡ Processing r1cs A,B,C {} took {:?}", subcircuit_id, t.elapsed());
+        // println!("    ⚡ Processing r1cs A,B,C {} took {:?}", subcircuit_id, t.elapsed());
     }
-    println!("🔄 Loading r1cs took {:?}", time_start.elapsed());
+    // println!("🔄 Loading r1cs took {:?}", time_start.elapsed());
     
     // Report cache statistics
     let total_cache_hits: usize = cache_stats.values().sum();

--- a/packages/backend/prove/Cargo.toml
+++ b/packages/backend/prove/Cargo.toml
@@ -20,3 +20,4 @@ tiny-keccak = "1.5"
 [features]
 default = []
 testing-mode = []
+timing = []

--- a/packages/backend/prove/output/timing.release.md
+++ b/packages/backend/prove/output/timing.release.md
@@ -1,0 +1,74 @@
+# Prove Timing Report
+
+## Total Time
+
+| item | value |
+| --- | --- |
+| total_wall | 71.049089 s |
+
+## Setup Parameters
+
+| param | value |
+| --- | --- |
+| l | 512 |
+| l_user_out | 8 |
+| l_user | 40 |
+| l_block | 64 |
+| l_D | 2560 |
+| m_D | 19972 |
+| n | 2048 |
+| s_D | 23 |
+| s_max | 256 |
+
+## Module Times (prove0~prove4)
+
+| module | total | poly | encode |
+| --- | --- | --- | --- |
+| prove0 | 8.995563 s | 4.999928 s | 3.848214 s |
+| prove1 | 1.151224 s | 0.570837 s | 0.549950 s |
+| prove2 | 33.943829 s | 24.666205 s | 3.137340 s |
+| prove3 | 1.329268 s | 0.991215 s | 0.000000 s |
+| prove4 | 12.462160 s | 0.891975 s | 4.238455 s |
+
+## Category Totals
+
+| category | total |
+| --- | --- |
+| poly | 32.120161 s |
+| encode | 11.773960 s |
+
+## Poly Operation Totals
+
+| operation | total |
+| --- | --- |
+| div_by_ruffini | 0.891975 s |
+| div_by_vanishing | 29.650872 s |
+| eval | 0.970700 s |
+| from_rou_evals | 0.082276 s |
+| recursion_eval | 0.333373 s |
+| scale_coeffs | 0.029031 s |
+| to_rou_evals | 0.161934 s |
+
+## Poly Operation Details (by variable)
+
+| operation | module | variable | time | dims |
+| --- | --- | --- | --- | --- |
+| div_by_ruffini | prove4 | M | 0.292459 s | R=2048x256 |
+| div_by_ruffini | prove4 | N | 0.286173 s | R=2048x256 |
+| div_by_ruffini | prove4 | Pi_C | 0.313342 s | LHS_for_copy=2048x256 |
+| div_by_vanishing | prove0 | q0q1 | 4.999928 s | p0XY=2048x256, vanishing=2048x256 |
+| div_by_vanishing | prove2 | q2q7 | 24.650944 s | p1/p2/p3=2048x256, vanishing=2048x256 |
+| eval | prove3 | R | 0.331216 s | R=2048x256 |
+| eval | prove3 | R_omegaX | 0.329017 s | R_omegaX=2048x256 |
+| eval | prove3 | R_omegaX_omegaY | 0.310467 s | R_omegaX_omegaY=2048x256 |
+| from_rou_evals | prove1 | rXY | 0.075531 s | rXY_evals=524288, grid=2048x256 |
+| from_rou_evals | prove2 | K | 0.002513 s | k_evals=2048, grid=2048x1 |
+| from_rou_evals | prove2 | K0 | 0.002494 s | k0_evals=2048, grid=2048x1 |
+| from_rou_evals | prove2 | L | 0.001739 s | l_evals=256, grid=1x256 |
+| recursion_eval | prove1 | rXY | 0.333373 s | fXY_evals=524288, gXY_evals=524288, grid=2048x256 |
+| scale_coeffs | prove2 | r_omegaX | 0.004111 s | rXY=2048x256 |
+| scale_coeffs | prove2 | r_omegaX_omegaY | 0.004405 s | r_omegaX=2048x256 |
+| scale_coeffs | prove3 | R_omegaX | 0.008655 s | R=2048x256 |
+| scale_coeffs | prove3 | R_omegaX_omegaY | 0.011860 s | R_omegaX=2048x256 |
+| to_rou_evals | prove1 | fXY | 0.084627 s | fXY=2048x256 |
+| to_rou_evals | prove1 | gXY | 0.077307 s | gXY=2048x256 |

--- a/packages/backend/prove/scripts/timing_to_md.py
+++ b/packages/backend/prove/scripts/timing_to_md.py
@@ -97,6 +97,27 @@ def build_report(data: dict) -> str:
     lines.append(f"| total_wall | {format_seconds(total_wall_ms)} |")
     lines.append("")
 
+    setup_params = data.get("setup_params")
+    if isinstance(setup_params, dict):
+        lines.append("## Setup Parameters")
+        lines.append("")
+        lines.append("| param | value |")
+        lines.append("| --- | --- |")
+        for key in [
+            "l",
+            "l_user_out",
+            "l_user",
+            "l_block",
+            "l_D",
+            "m_D",
+            "n",
+            "s_D",
+            "s_max",
+        ]:
+            if key in setup_params:
+                lines.append(f"| {key} | {setup_params[key]} |")
+        lines.append("")
+
     lines.append("## Module Times (prove0~prove4)")
     lines.append("")
     lines.append("| module | total | poly | encode |")

--- a/packages/backend/prove/scripts/timing_to_md.py
+++ b/packages/backend/prove/scripts/timing_to_md.py
@@ -1,0 +1,175 @@
+import argparse
+import json
+import os
+from collections import defaultdict
+
+
+def load_json(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def format_seconds(ms: float) -> str:
+    return f"{(ms / 1000.0):,.6f} s"
+
+
+def format_dims(dims):
+    if not dims:
+        return "-"
+    if len(dims) == 1:
+        return f"{dims[0]}"
+    return "x".join(str(d) for d in dims)
+
+
+def sizes_to_string(sizes):
+    if not sizes:
+        return "-"
+    parts = []
+    for item in sizes:
+        label = item.get("label", "size")
+        dims = item.get("dims", [])
+        parts.append(f"{label}={format_dims(dims)}")
+    return ", ".join(parts)
+
+
+def parse_poly_event(name: str):
+    # Expected: poly.<op>.<proveX>.<var>
+    parts = name.split(".")
+    if len(parts) < 4:
+        return None
+    if parts[0] != "poly":
+        return None
+    op = parts[1]
+    module = None
+    var = parts[-1]
+    for part in parts[2:-1]:
+        if part.startswith("prove"):
+            module = part
+            break
+    if module is None:
+        module = parts[2]
+    return op, module, var
+
+
+def build_report(data: dict) -> str:
+    total_wall_ms = data.get("total_wall_ms", 0.0)
+    summary = data.get("summary", {})
+    events = data.get("events", [])
+
+    poly_total = 0.0
+    encode_total = 0.0
+    for e in events:
+        ms = e.get("nanos", 0) / 1_000_000.0
+        if e.get("category") == "poly":
+            poly_total += ms
+        elif e.get("category") == "encode":
+            encode_total += ms
+
+    poly_op_totals = defaultdict(float)
+    poly_event_rows = []
+    for e in events:
+        if e.get("category") != "poly":
+            continue
+        parsed = parse_poly_event(e.get("name", ""))
+        if parsed is None:
+            continue
+        op, module, var = parsed
+        ms = e.get("nanos", 0) / 1_000_000.0
+        poly_op_totals[op] += ms
+        poly_event_rows.append(
+            {
+                "op": op,
+                "module": module,
+                "var": var,
+                "ms": ms,
+                "sizes": sizes_to_string(e.get("sizes", [])),
+            }
+        )
+
+    lines = []
+    lines.append("# Prove Timing Report")
+    lines.append("")
+
+    lines.append("## Total Time")
+    lines.append("")
+    lines.append("| item | value |")
+    lines.append("| --- | --- |")
+    lines.append(f"| total_wall | {format_seconds(total_wall_ms)} |")
+    lines.append("")
+
+    lines.append("## Module Times (prove0~prove4)")
+    lines.append("")
+    lines.append("| module | total | poly | encode |")
+    lines.append("| --- | --- | --- | --- |")
+    for module in ["prove0", "prove1", "prove2", "prove3", "prove4"]:
+        item = summary.get(module, {})
+        lines.append(
+            f"| {module} | {format_seconds(item.get('total_ms', 0.0))} | "
+            f"{format_seconds(item.get('poly_ms', 0.0))} | {format_seconds(item.get('encode_ms', 0.0))} |"
+        )
+    lines.append("")
+
+    lines.append("## Category Totals")
+    lines.append("")
+    lines.append("| category | total |")
+    lines.append("| --- | --- |")
+    lines.append(f"| poly | {format_seconds(poly_total)} |")
+    lines.append(f"| encode | {format_seconds(encode_total)} |")
+    lines.append("")
+
+    lines.append("## Poly Operation Totals")
+    lines.append("")
+    lines.append("| operation | total |")
+    lines.append("| --- | --- |")
+    for op in sorted(poly_op_totals.keys()):
+        lines.append(f"| {op} | {format_seconds(poly_op_totals[op])} |")
+    lines.append("")
+
+    lines.append("## Poly Operation Details (by variable)")
+    lines.append("")
+    lines.append("| operation | module | variable | time | dims |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for row in sorted(poly_event_rows, key=lambda r: (r["op"], r["module"], r["var"])):
+        lines.append(
+            f"| {row['op']} | {row['module']} | {row['var']} | {format_seconds(row['ms'])} | {row['sizes']} |"
+        )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert timing JSON to Markdown report.")
+    parser.add_argument(
+        "--input",
+        default=os.getenv("TIMING_OUT", ""),
+        help="Path to timing JSON (default: TIMING_OUT env).",
+    )
+    parser.add_argument(
+        "--output",
+        default="",
+        help="Path to output Markdown file.",
+    )
+    args = parser.parse_args()
+
+    if not args.input:
+        raise SystemExit("Missing --input and TIMING_OUT is not set.")
+
+    input_path = args.input
+    output_path = args.output
+    if not output_path:
+        base, ext = os.path.splitext(input_path)
+        output_path = f"{base}.md" if ext else f"{input_path}.md"
+
+    data = load_json(input_path)
+    report = build_report(data)
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(report)
+
+    print(f"Wrote report: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/backend/prove/src/lib.rs
+++ b/packages/backend/prove/src/lib.rs
@@ -649,7 +649,6 @@
                 Mixer {rB_X, rB_Y, rR_X, rR_Y, rU_X, rU_Y, rV_X, rV_Y, rW_X, rW_Y, rO_mid}
             };
 
-            println!("Check point: Fetched input data from the frontend compilers");
 
             let time_start = Instant::now();
             println!("🔄 Starting binding computation (MSMs)...");
@@ -696,7 +695,6 @@
             };
             println!("🔄 Binding computation (MSMs) took {:?}", time_start.elapsed());
 
-            println!("Check point: Encoded binding polynomials");
 
             return (
                 Self {sigma, setup_params, instance, witness, mixer, quotients},
@@ -793,7 +791,6 @@
                 self.mixer.rW_Y.len()
             );
 
-            println!("Check point: Computed quotient polynomials for Arithmetic constraint argument");
 
             let U = {
                 let mut UXY = poly_comb!(
@@ -846,7 +843,6 @@
                 })
             };
 
-            println!("Check point: Encoded witness polynomials for Arithmetic constraint argument");
             
             let Q_AX = {
                 let mut Q_AX_XY = poly_comb!(
@@ -890,7 +886,6 @@
             drop(rW_X);
             drop(rW_Y);
 
-            println!("Check point: Encoded the quotient polynomials for Arithmetic constraint argument");
 
             let B = {
                 let rB_X = DensePolynomialExt::from_coeffs(
@@ -916,7 +911,6 @@
                 })
             };
 
-            println!("Check point: Encoded the witness polynomial for Copy constraint argument");
             return Proof0 {U, V, W, Q_AX, Q_AY, B}
         }
 
@@ -1033,7 +1027,6 @@
             // Adding zero-knowledge to the copy constraint argument
             let mut RXY = &self.witness.rXY + &(&(&self.mixer.rR_X * &self.instance.t_mi) + &(&self.mixer.rR_Y * &self.instance.t_smax));
 
-            println!("Check point: Computed a recursion polynomial for Copy constraint argument");
 
 
             let R = crate::time_block!(
@@ -1046,7 +1039,6 @@
                 self.sigma.sigma_1.encode_poly(&mut RXY, &self.setup_params)
             });
 
-            println!("Check point: Encoded the recursion polynomial for Copy constraint argument");
 
             return Proof1 {R}
         }
@@ -1210,7 +1202,6 @@
                 (q2XY, q3XY, q4XY, q5XY, q6XY, q7XY)
             });
 
-            println!("Check point: Computed quotient polynomials for Copy constraint argument");
             
             
             // Adding zero-knowledge to the copy constraint argument
@@ -1288,7 +1279,6 @@
                 })
             };
 
-            println!("Check point: Encoded quotient polynomials for Copy constraint argument");
             return Proof2 {Q_CX, Q_CY}
         }
 
@@ -1365,7 +1355,6 @@
                 R_omegaX_omegaY_XY.eval(&chi, &zeta)
             });
 
-            println!("Check point: Computed KZG openings");
 
             return Proof3 {
                 V_eval: FieldSerde(V_eval), 
@@ -1431,7 +1420,6 @@
                     pA_XY.div_by_ruffini(&chi, &zeta)
                 };
 
-                println!("Check point: Computed KZG proofs for Arithmetic constraint argument");
 
                 (
                     crate::time_block!(
@@ -1455,7 +1443,6 @@
                 )
             };
 
-            println!("Check point: Encoded the KZG proofs for Arithmetic constraint argument");
 
             let omega_m_i = ntt::get_root_of_unity::<ScalarField>(m_i as u64);
             let omega_s_max = ntt::get_root_of_unity::<ScalarField>(s_max as u64);
@@ -1482,7 +1469,6 @@
                     assert_eq!(lhs, rhs);
                 }
 
-                println!("Check point: Computed KZG proofs for the recursion polynomials (1/2)");
 
                 (
                     crate::time_block!(
@@ -1506,7 +1492,6 @@
                 )
             };
 
-            println!("Check point: Encoded the KZG proofs for the recursion polynomials (1/2)");
 
             let (N_X, N_Y) = {
                 let (mut N_X_XY, mut N_Y_XY, rem3) = crate::time_block!(
@@ -1530,7 +1515,6 @@
                     assert_eq!(lhs, rhs);
                 }
 
-                println!("Check point: Computed KZG proofs for the recursion polynomials (2/2)");
 
                 (
                     crate::time_block!(
@@ -1554,7 +1538,6 @@
                 )
             };
 
-            println!("Check point: Encoded the KZG proofs for the recursion polynomials (2/2)");
             
             let (Pi_CX, Pi_CY) = {
                 let LHS_for_copy = {
@@ -1699,7 +1682,6 @@
                     assert_eq!(lhs, rhs);
                 }
 
-                println!("Check point: Computed KZG proofs for Copy constraint argument");
 
                 (
                     crate::time_block!(
@@ -1726,14 +1708,12 @@
                 println!("Checked: B(X,Y) and R(X,Y) with zero-knowledge satisfy the copy constraints.")
             }
 
-            println!("Check point: Encoded the KZG proofs for Copy constraint argument");
 
             drop(RXY);
             let Pi_B = {
                 let A_eval = self.instance.a_pub_X.eval(&chi, &zeta);
                 let (mut pi_B_XY, _, _) = (&self.instance.a_pub_X - &A_eval).div_by_ruffini(&chi, &zeta);
 
-                println!("Check point: Computed a KZG proof for public instance");
 
                 crate::time_block!(
                     "prove4.encode.Pi_B",
@@ -1746,7 +1726,6 @@
                 }) * kappa1.pow(4)
             };
 
-            println!("Check point: Encoded the KZG proof for public instance");
 
             let Pi_X = Pi_AX + Pi_CX + Pi_B;
             let Pi_Y = Pi_AY + Pi_CY;

--- a/packages/backend/prove/tests/timing.rs
+++ b/packages/backend/prove/tests/timing.rs
@@ -19,9 +19,24 @@ struct StageSummary {
 
 #[cfg(feature = "timing")]
 #[derive(serde::Serialize)]
+struct SetupParamsSummary {
+    l: usize,
+    l_user_out: usize,
+    l_user: usize,
+    l_block: usize,
+    l_D: usize,
+    m_D: usize,
+    n: usize,
+    s_D: usize,
+    s_max: usize,
+}
+
+#[cfg(feature = "timing")]
+#[derive(serde::Serialize)]
 struct TimingReport {
     generated_at_unix_ms: u128,
     total_wall_ms: f64,
+    setup_params: SetupParamsSummary,
     summary: BTreeMap<String, StageSummary>,
     events: Vec<timing::TimingEvent>,
 }
@@ -78,6 +93,17 @@ fn timing_prove_stages() {
     let wall_start = Instant::now();
 
     let (mut prover, _binding) = Prover::init(&paths);
+    let setup_params = SetupParamsSummary {
+        l: prover.setup_params.l,
+        l_user_out: prover.setup_params.l_user_out,
+        l_user: prover.setup_params.l_user,
+        l_block: prover.setup_params.l_block,
+        l_D: prover.setup_params.l_D,
+        m_D: prover.setup_params.m_D,
+        n: prover.setup_params.n,
+        s_D: prover.setup_params.s_D,
+        s_max: prover.setup_params.s_max,
+    };
     let mut manager = TranscriptManager::new();
 
     let proof0 = prover.prove0();
@@ -144,6 +170,7 @@ fn timing_prove_stages() {
     let report = TimingReport {
         generated_at_unix_ms,
         total_wall_ms,
+        setup_params,
         summary,
         events,
     };

--- a/packages/backend/prove/tests/timing.rs
+++ b/packages/backend/prove/tests/timing.rs
@@ -1,0 +1,165 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use prove::{ProveInputPaths, Prover, TranscriptManager};
+
+#[cfg(feature = "timing")]
+use prove::timing;
+
+#[cfg(feature = "timing")]
+#[derive(serde::Serialize)]
+struct StageSummary {
+    total_ms: f64,
+    poly_ms: f64,
+    encode_ms: f64,
+}
+
+#[cfg(feature = "timing")]
+#[derive(serde::Serialize)]
+struct TimingReport {
+    generated_at_unix_ms: u128,
+    total_wall_ms: f64,
+    summary: BTreeMap<String, StageSummary>,
+    events: Vec<timing::TimingEvent>,
+}
+
+fn read_env(name: &str) -> Option<String> {
+    env::var(name).ok().and_then(|v| {
+        if v.trim().is_empty() {
+            None
+        } else {
+            Some(v)
+        }
+    })
+}
+
+#[cfg(feature = "timing")]
+#[test]
+fn timing_prove_stages() {
+    let qap_path = match read_env("PROVE_QAP_PATH") {
+        Some(v) => v,
+        None => {
+            eprintln!("Skipping timing test: PROVE_QAP_PATH is not set.");
+            return;
+        }
+    };
+    let synthesizer_path = match read_env("PROVE_SYNTHESIZER_PATH") {
+        Some(v) => v,
+        None => {
+            eprintln!("Skipping timing test: PROVE_SYNTHESIZER_PATH is not set.");
+            return;
+        }
+    };
+    let setup_path = match read_env("PROVE_SETUP_PATH") {
+        Some(v) => v,
+        None => {
+            eprintln!("Skipping timing test: PROVE_SETUP_PATH is not set.");
+            return;
+        }
+    };
+    let output_path = read_env("PROVE_OUT_PATH").unwrap_or_else(|| "prove/output".to_string());
+
+    let output_dir = PathBuf::from(&output_path);
+    if let Err(err) = fs::create_dir_all(&output_dir) {
+        eprintln!("Failed to create output dir {output_path}: {err}");
+    }
+
+    let paths = ProveInputPaths {
+        qap_path: &qap_path,
+        synthesizer_path: &synthesizer_path,
+        setup_path: &setup_path,
+        output_path: &output_path,
+    };
+
+    timing::reset();
+    let wall_start = Instant::now();
+
+    let (mut prover, _binding) = Prover::init(&paths);
+    let mut manager = TranscriptManager::new();
+
+    let proof0 = prover.prove0();
+    let thetas = proof0.verify0_with_manager(&mut manager);
+
+    let proof1 = prover.prove1(&thetas);
+    let kappa0 = proof1.verify1_with_manager(&mut manager);
+
+    let proof2 = prover.prove2(&thetas, kappa0);
+    let (chi, zeta) = proof2.verify2_with_manager(&mut manager);
+
+    let proof3 = prover.prove3(chi, zeta);
+    let kappa1 = proof3.verify3_with_manager(&mut manager);
+
+    let (_proof4, _proof4_test) = prover.prove4(&proof3, &thetas, kappa0, chi, zeta, kappa1);
+
+    let total_wall_ms = wall_start.elapsed().as_secs_f64() * 1000.0;
+    let events = timing::take_events();
+
+    let mut summary: BTreeMap<String, StageSummary> = BTreeMap::new();
+    for event in &events {
+        let mut stage = None;
+        for part in event.name.split('.') {
+            if part.starts_with("prove") {
+                stage = Some(part.to_string());
+                break;
+            }
+        }
+        let stage = stage.unwrap_or_else(|| {
+            event
+                .name
+                .split('.')
+                .next()
+                .unwrap_or(event.name)
+                .to_string()
+        });
+        let entry = summary.entry(stage).or_insert(StageSummary {
+            total_ms: 0.0,
+            poly_ms: 0.0,
+            encode_ms: 0.0,
+        });
+        let ms = event.nanos as f64 / 1_000_000.0;
+        match event.category {
+            "poly" => entry.poly_ms += ms,
+            "encode" => entry.encode_ms += ms,
+            _ => {}
+        }
+        if event.name.ends_with(".total") {
+            entry.total_ms += ms;
+        }
+    }
+
+    for entry in summary.values_mut() {
+        if entry.total_ms == 0.0 {
+            entry.total_ms = entry.poly_ms + entry.encode_ms;
+        }
+    }
+
+    let generated_at_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+
+    let report = TimingReport {
+        generated_at_unix_ms,
+        total_wall_ms,
+        summary,
+        events,
+    };
+
+    let report_json = serde_json::to_string_pretty(&report).expect("failed to serialize timing report");
+    if let Some(out_path) = read_env("TIMING_OUT") {
+        if let Err(err) = fs::write(&out_path, report_json.as_bytes()) {
+            eprintln!("Failed to write timing report to {out_path}: {err}");
+        }
+    } else {
+        println!("{report_json}");
+    }
+}
+
+#[cfg(not(feature = "timing"))]
+#[test]
+fn timing_prove_stages_disabled() {
+    eprintln!("timing feature is disabled; run with --features timing to collect metrics.");
+}


### PR DESCRIPTION
## Summary
- add timing instrumentation with sizes and hierarchical event names
- add JSON→Markdown report generator and VSCode wiring
- include timing.release.md while keeping other output ignored
- remove Check point logs

## Changes
- add timing collection and size metadata in prove
- add timing report converter script (JSON → MD)
- add VSCode launch/task for timing test
- update gitignore to keep only timing.release.md in prove/output

## Tests
- [x] cargo test -p prove --release --features timing --test timing -- --nocapture

## Notes
- timing.release.json is raw data for report generation
