### PR TITLE
Optimize backend polynomial expression evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## [2.1.3] - 2026-07-27
+
+### Repository
+
+- Synchronized the release version to `2.1.3` across the CLI, subcircuit library, synthesizer packages, and backend workspace.
+
+### CLI
+
+- Bumped `@tokamak-zk-evm/cli` to `2.1.3` and updated its `@tokamak-zk-evm/synthesizer-node` dependency to `^2.1.3`.
+- Kept `packages/cli/package.json tokamakZkEvm.compatibleBackendVersion` at `2.1`.
+
+### Subcircuit Library
+
+- Bumped `@tokamak-zk-evm/subcircuit-library` to `2.1.3`.
+
+### Synthesizer
+
+- Bumped `@tokamak-zk-evm/synthesizer-node` and `@tokamak-zk-evm/synthesizer-web` to `2.1.3`.
+- Updated both synthesizer packages to consume `@tokamak-zk-evm/subcircuit-library` through the synchronized `^2.1.3` dependency range.
+
+### Backend Workspace
+
+- Bumped the backend Rust workspace version to `2.1.3`.
+- Added a typed polynomial expression evaluator with coefficient-domain and fused evaluation-domain execution, and applied the fused path to the prover's `prove2.p_comb` expression.
+- Added focused correctness coverage, prover operation diagnostics, and timing benchmarks for fused polynomial expression candidates.
+- Stabilized backend library tests by serializing test execution and making NTT domain initialization reusable.
+- Updated stale VS Code launch arguments and ignored backend-local temporary planning files.
+
 ## [2.1.2] - 2026-07-18
 
 ### Repository

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokamak-zk-evm-monorepo",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokamak-zk-evm-monorepo",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT OR Apache-2.0",
       "workspaces": [
         "packages/cli",
@@ -8643,10 +8643,10 @@
     },
     "packages/cli": {
       "name": "@tokamak-zk-evm/cli",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tokamak-zk-evm/synthesizer-node": "^2.1.2",
+        "@tokamak-zk-evm/synthesizer-node": "^2.1.3",
         "adm-zip": "^0.5.17"
       },
       "bin": {
@@ -8663,7 +8663,7 @@
     },
     "packages/frontend/qap-compiler": {
       "name": "@tokamak-zk-evm/subcircuit-library",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "os": [
@@ -18096,7 +18096,7 @@
     },
     "packages/frontend/synthesizer/node-cli": {
       "name": "@tokamak-zk-evm/synthesizer-node",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@ethereumjs/block": "^10.0.0",
@@ -18109,7 +18109,7 @@
         "@ethereumjs/vm": "^10.0.0",
         "@js-sdsl/ordered-map": "^4.4.2",
         "@noble/curves": "1.9.7",
-        "@tokamak-zk-evm/subcircuit-library": "^2.1.2",
+        "@tokamak-zk-evm/subcircuit-library": "^2.1.3",
         "@types/debug": "^4.1.9",
         "@vitest/coverage-v8": "^2.1.8",
         "@zk-kit/imt": "2.0.0-beta.8",
@@ -18169,7 +18169,7 @@
     },
     "packages/frontend/synthesizer/web-app": {
       "name": "@tokamak-zk-evm/synthesizer-web",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@ethereumjs/block": "^10.0.0",
@@ -18178,7 +18178,7 @@
         "@ethereumjs/util": "^10.0.0",
         "@ethereumjs/vm": "^10.0.0",
         "@noble/curves": "1.9.7",
-        "@tokamak-zk-evm/subcircuit-library": "^2.1.2",
+        "@tokamak-zk-evm/subcircuit-library": "^2.1.3",
         "@zk-kit/imt": "2.0.0-beta.8",
         "tokamak-l2js": "^0.1.4"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokamak-zk-evm-monorepo",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Tokamak zk-EVM: A tool that converts Ethereum transactions into Zero-Knowledge Proofs",
   "license": "MIT OR Apache-2.0",
   "author": "Tokamak Network",

--- a/packages/backend/.cargo/config.toml
+++ b/packages/backend/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 rustflags = ["-C", "link-args=-Wl,-rpath,/app/target/debug/deps"]
+
+[env]
+RUST_TEST_THREADS = "1"

--- a/packages/backend/.gitignore
+++ b/packages/backend/.gitignore
@@ -1,5 +1,6 @@
 /target
 /external-lib
+/tmp
 .env
 gen-lang-client-*.json
 client_secret_*.json

--- a/packages/backend/.vscode/launch.json
+++ b/packages/backend/.vscode/launch.json
@@ -154,6 +154,8 @@
       },
       "program": "${cargo:program}",
       "args": [
+        "--subcircuit-library",
+        "${workspaceFolder}/../frontend/qap-compiler/subcircuits/library",
         "--crs",
         "${workspaceFolder}/setup/output",
         "--synthesizer-stat",
@@ -282,8 +284,6 @@
       },
       "program": "${cargo:program}",
       "args": [
-        "--subcircuit-library",
-        "${workspaceFolder}/../frontend/qap-compiler/subcircuits/library",
         "--crs",
         "${workspaceFolder}/setup/output",
         "--synthesizer-stat",

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "2.1.2"
+version = "2.1.3"
 license = "MIT OR Apache-2.0"
 authors = ["Tokamak Network"]
 repository = "https://github.com/tokamak-network/tokamak-zk-evm"

--- a/packages/backend/libs/src/bivariate_polynomial/mod.rs
+++ b/packages/backend/libs/src/bivariate_polynomial/mod.rs
@@ -11,6 +11,7 @@ use rayon::prelude::*;
 use std::time::Instant;
 use std::{
     cmp,
+    collections::HashMap,
     ops::{Add, AddAssign, Mul, Neg, Sub},
     sync::{Mutex, OnceLock},
 };
@@ -122,6 +123,288 @@ impl DensePolynomialExt {
         let (x_degree, y_degree) = self.find_degree();
         x_degree == -1 && y_degree == -1
     }
+}
+
+#[derive(Clone)]
+pub enum PolyExpr<'a> {
+    Poly(&'a DensePolynomialExt),
+    Scalar(ScalarField),
+    Add(Box<PolyExpr<'a>>, Box<PolyExpr<'a>>),
+    Sub(Box<PolyExpr<'a>>, Box<PolyExpr<'a>>),
+    Mul(Box<PolyExpr<'a>>, Box<PolyExpr<'a>>),
+    Scale(ScalarField, Box<PolyExpr<'a>>),
+    MulXMinusOne(Box<PolyExpr<'a>>),
+    Sum(Vec<PolyExpr<'a>>),
+}
+
+impl<'a> PolyExpr<'a> {
+    pub fn poly(poly: &'a DensePolynomialExt) -> Self {
+        Self::Poly(poly)
+    }
+
+    pub fn scalar(scalar: ScalarField) -> Self {
+        Self::Scalar(scalar)
+    }
+
+    pub fn add(lhs: Self, rhs: Self) -> Self {
+        Self::Add(Box::new(lhs), Box::new(rhs))
+    }
+
+    pub fn sub(lhs: Self, rhs: Self) -> Self {
+        Self::Sub(Box::new(lhs), Box::new(rhs))
+    }
+
+    pub fn mul(lhs: Self, rhs: Self) -> Self {
+        Self::Mul(Box::new(lhs), Box::new(rhs))
+    }
+
+    pub fn scale(scalar: ScalarField, expr: Self) -> Self {
+        Self::Scale(scalar, Box::new(expr))
+    }
+
+    pub fn mul_x_minus_one(expr: Self) -> Self {
+        Self::MulXMinusOne(Box::new(expr))
+    }
+
+    pub fn weighted_sum(terms: Vec<(ScalarField, Self)>) -> Self {
+        Self::Sum(
+            terms
+                .into_iter()
+                .map(|(scalar, expr)| Self::scale(scalar, expr))
+                .collect(),
+        )
+    }
+
+    pub fn evaluate_coeffs(&self) -> DensePolynomialExt {
+        match self {
+            Self::Poly(poly) => (*poly).clone(),
+            Self::Scalar(scalar) => {
+                let coeffs = [*scalar];
+                DensePolynomialExt::from_coeffs(HostSlice::from_slice(&coeffs), 1, 1)
+            }
+            Self::Add(lhs, rhs) => &lhs.evaluate_coeffs() + &rhs.evaluate_coeffs(),
+            Self::Sub(lhs, rhs) => &lhs.evaluate_coeffs() - &rhs.evaluate_coeffs(),
+            Self::Mul(lhs, rhs) => &lhs.evaluate_coeffs() * &rhs.evaluate_coeffs(),
+            Self::Scale(scalar, expr) => &expr.evaluate_coeffs() * scalar,
+            Self::MulXMinusOne(expr) => {
+                let poly = expr.evaluate_coeffs();
+                let shifted = poly.mul_monomial(1, 0);
+                &shifted - &poly
+            }
+            Self::Sum(terms) => {
+                let mut iter = terms.iter();
+                let Some(first) = iter.next() else {
+                    return DensePolynomialExt::zero();
+                };
+                let mut acc = first.evaluate_coeffs();
+                for term in iter {
+                    acc += &term.evaluate_coeffs();
+                }
+                acc
+            }
+        }
+    }
+
+    pub fn evaluate_fused(&self) -> DensePolynomialExt {
+        let (x_degree, y_degree) = self.degree_bound();
+        let x_size = domain_size_for_degree(x_degree);
+        let y_size = domain_size_for_degree(y_degree);
+        self.evaluate_fused_with_domain(x_size, y_size)
+    }
+
+    pub fn evaluate_fused_with_domain(
+        &self,
+        target_x_size: usize,
+        target_y_size: usize,
+    ) -> DensePolynomialExt {
+        if !target_x_size.is_power_of_two() || !target_y_size.is_power_of_two() {
+            panic!("Fused polynomial expression domains must be powers of two.");
+        }
+        let (x_degree, y_degree) = self.degree_bound();
+        if domain_size_for_degree(x_degree) > target_x_size
+            || domain_size_for_degree(y_degree) > target_y_size
+        {
+            panic!("Fused polynomial expression domain is too small for the expression degree.");
+        }
+        let mut leaf_cache = HashMap::new();
+        let evals = self.evaluate_on_domain(target_x_size, target_y_size, &mut leaf_cache);
+        DensePolynomialExt::from_rou_evals(&evals, target_x_size, target_y_size, None, None)
+    }
+
+    fn degree_bound(&self) -> (i64, i64) {
+        match self {
+            Self::Poly(poly) => poly.find_degree(),
+            Self::Scalar(scalar) => {
+                if *scalar == ScalarField::zero() {
+                    (-1, -1)
+                } else {
+                    (0, 0)
+                }
+            }
+            Self::Add(lhs, rhs) | Self::Sub(lhs, rhs) => {
+                let lhs_degree = lhs.degree_bound();
+                let rhs_degree = rhs.degree_bound();
+                (
+                    cmp::max(lhs_degree.0, rhs_degree.0),
+                    cmp::max(lhs_degree.1, rhs_degree.1),
+                )
+            }
+            Self::Mul(lhs, rhs) => {
+                let lhs_degree = lhs.degree_bound();
+                let rhs_degree = rhs.degree_bound();
+                if lhs_degree.0 < 0 || lhs_degree.1 < 0 || rhs_degree.0 < 0 || rhs_degree.1 < 0 {
+                    (-1, -1)
+                } else {
+                    (lhs_degree.0 + rhs_degree.0, lhs_degree.1 + rhs_degree.1)
+                }
+            }
+            Self::Scale(scalar, expr) => {
+                if *scalar == ScalarField::zero() {
+                    (-1, -1)
+                } else {
+                    expr.degree_bound()
+                }
+            }
+            Self::MulXMinusOne(expr) => {
+                let degree = expr.degree_bound();
+                if degree.0 < 0 || degree.1 < 0 {
+                    (-1, -1)
+                } else {
+                    (degree.0 + 1, degree.1)
+                }
+            }
+            Self::Sum(terms) => terms.iter().fold((-1, -1), |acc, term| {
+                let degree = term.degree_bound();
+                (cmp::max(acc.0, degree.0), cmp::max(acc.1, degree.1))
+            }),
+        }
+    }
+
+    fn evaluate_on_domain(
+        &self,
+        x_size: usize,
+        y_size: usize,
+        leaf_cache: &mut HashMap<(usize, usize, usize), DeviceVec<ScalarField>>,
+    ) -> DeviceVec<ScalarField> {
+        let size = x_size * y_size;
+        let vec_ops_cfg = VecOpsConfig::default();
+        match self {
+            Self::Poly(poly) => eval_poly_leaf(poly, x_size, y_size, leaf_cache),
+            Self::Scalar(scalar) => device_vec_from_scalar(*scalar, size),
+            Self::Add(lhs, rhs) => {
+                let lhs_evals = lhs.evaluate_on_domain(x_size, y_size, leaf_cache);
+                let rhs_evals = rhs.evaluate_on_domain(x_size, y_size, leaf_cache);
+                let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                ScalarCfg::add(&lhs_evals, &rhs_evals, &mut out, &vec_ops_cfg).unwrap();
+                out
+            }
+            Self::Sub(lhs, rhs) => {
+                let lhs_evals = lhs.evaluate_on_domain(x_size, y_size, leaf_cache);
+                let rhs_evals = rhs.evaluate_on_domain(x_size, y_size, leaf_cache);
+                let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                ScalarCfg::sub(&lhs_evals, &rhs_evals, &mut out, &vec_ops_cfg).unwrap();
+                out
+            }
+            Self::Mul(lhs, rhs) => {
+                let lhs_evals = lhs.evaluate_on_domain(x_size, y_size, leaf_cache);
+                let rhs_evals = rhs.evaluate_on_domain(x_size, y_size, leaf_cache);
+                let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                ScalarCfg::mul(&lhs_evals, &rhs_evals, &mut out, &vec_ops_cfg).unwrap();
+                out
+            }
+            Self::Scale(scalar, expr) => {
+                let expr_evals = expr.evaluate_on_domain(x_size, y_size, leaf_cache);
+                if *scalar == ScalarField::one() {
+                    return expr_evals;
+                }
+                let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                let scaler = [*scalar];
+                ScalarCfg::scalar_mul(
+                    HostSlice::from_slice(&scaler),
+                    &expr_evals,
+                    &mut out,
+                    &vec_ops_cfg,
+                )
+                .unwrap();
+                out
+            }
+            Self::MulXMinusOne(expr) => {
+                let expr_evals = expr.evaluate_on_domain(x_size, y_size, leaf_cache);
+                let x_minus_one = x_minus_one_evals(x_size, y_size);
+                let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                ScalarCfg::mul(&expr_evals, &x_minus_one, &mut out, &vec_ops_cfg).unwrap();
+                out
+            }
+            Self::Sum(terms) => {
+                let mut out = device_vec_from_scalar(ScalarField::zero(), size);
+                for term in terms {
+                    let term_evals = term.evaluate_on_domain(x_size, y_size, leaf_cache);
+                    let mut next = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                    ScalarCfg::add(&out, &term_evals, &mut next, &vec_ops_cfg).unwrap();
+                    out = next;
+                }
+                out
+            }
+        }
+    }
+}
+
+fn domain_size_for_degree(degree: i64) -> usize {
+    if degree < 0 {
+        1
+    } else {
+        (degree as usize + 1).next_power_of_two()
+    }
+}
+
+fn copy_device_vec(src: &DeviceVec<ScalarField>, len: usize) -> DeviceVec<ScalarField> {
+    let mut out = DeviceVec::<ScalarField>::device_malloc(len).unwrap();
+    out.copy(src).unwrap();
+    out
+}
+
+fn device_vec_from_scalar(scalar: ScalarField, len: usize) -> DeviceVec<ScalarField> {
+    let values = vec![scalar; len];
+    let mut out = DeviceVec::<ScalarField>::device_malloc(len).unwrap();
+    out.copy_from_host(HostSlice::from_slice(&values)).unwrap();
+    out
+}
+
+fn eval_poly_leaf(
+    poly: &DensePolynomialExt,
+    x_size: usize,
+    y_size: usize,
+    leaf_cache: &mut HashMap<(usize, usize, usize), DeviceVec<ScalarField>>,
+) -> DeviceVec<ScalarField> {
+    let len = x_size * y_size;
+    let key = (poly as *const DensePolynomialExt as usize, x_size, y_size);
+    if let Some(cached) = leaf_cache.get(&key) {
+        return copy_device_vec(cached, len);
+    }
+
+    let mut resized = poly.clone();
+    resized.resize(x_size, y_size);
+    let mut evals = DeviceVec::<ScalarField>::device_malloc(len).unwrap();
+    resized.to_rou_evals(None, None, &mut evals);
+    let out = copy_device_vec(&evals, len);
+    leaf_cache.insert(key, evals);
+    out
+}
+
+fn x_minus_one_evals(x_size: usize, y_size: usize) -> DeviceVec<ScalarField> {
+    let omega_x = ntt::get_root_of_unity::<ScalarField>(x_size as u64);
+    let mut values = vec![ScalarField::zero(); x_size * y_size];
+    let mut x = ScalarField::one();
+    for x_idx in 0..x_size {
+        let factor = x - ScalarField::one();
+        for y_idx in 0..y_size {
+            values[x_idx * y_size + y_idx] = factor;
+        }
+        x = x * omega_x;
+    }
+    let mut out = DeviceVec::<ScalarField>::device_malloc(values.len()).unwrap();
+    out.copy_from_host(HostSlice::from_slice(&values)).unwrap();
+    out
 }
 
 impl Clone for DensePolynomialExt {

--- a/packages/backend/libs/src/bivariate_polynomial/mod.rs
+++ b/packages/backend/libs/src/bivariate_polynomial/mod.rs
@@ -31,26 +31,38 @@ fn ntt_domain_size_cell() -> &'static Mutex<Option<usize>> {
 }
 
 pub fn init_ntt_domain_for_size(size: usize) -> Result<(), icicle_runtime::errors::eIcicleError> {
-    if size == 0 {
+    let domain_size = requested_ntt_domain_size(size);
+    if domain_size == 0 {
         panic!("NTT domain size must be non-zero.");
     }
-    if !size.is_power_of_two() {
+    if !domain_size.is_power_of_two() {
         panic!("NTT domain size must be a power of two.");
     }
 
     let mut guard = ntt_domain_size_cell().lock().unwrap();
     if let Some(current) = *guard {
-        if current == size {
+        if current >= domain_size {
             return Ok(());
         }
         ntt::release_domain::<ScalarField>()?;
     }
     ntt::initialize_domain::<ScalarField>(
-        ntt::get_root_of_unity::<ScalarField>(size as u64),
+        ntt::get_root_of_unity::<ScalarField>(domain_size as u64),
         &ntt::NTTInitDomainConfig::default(),
     )?;
-    *guard = Some(size);
+    *guard = Some(domain_size);
     Ok(())
+}
+
+fn requested_ntt_domain_size(size: usize) -> usize {
+    #[cfg(test)]
+    {
+        cmp::max(size, 1 << 22)
+    }
+    #[cfg(not(test))]
+    {
+        size
+    }
 }
 
 fn get_ntt_domain_size() -> Option<usize> {

--- a/packages/backend/libs/src/bivariate_polynomial/mod.rs
+++ b/packages/backend/libs/src/bivariate_polynomial/mod.rs
@@ -240,7 +240,23 @@ impl<'a> PolyExpr<'a> {
         }
         let mut leaf_cache = HashMap::new();
         let evals = self.evaluate_on_domain(target_x_size, target_y_size, &mut leaf_cache);
-        DensePolynomialExt::from_rou_evals(&evals, target_x_size, target_y_size, None, None)
+        #[cfg(feature = "timing")]
+        let start = Instant::now();
+        let result = DensePolynomialExt::from_rou_evals(
+            &evals,
+            target_x_size,
+            target_y_size,
+            None,
+            None,
+        );
+        #[cfg(feature = "timing")]
+        record_detail_step(
+            "fused_final_from_rou_evals",
+            start,
+            "evals",
+            vec![target_x_size, target_y_size],
+        );
+        result
     }
 
     fn degree_bound(&self) -> (i64, i64) {
@@ -306,22 +322,46 @@ impl<'a> PolyExpr<'a> {
             Self::Add(lhs, rhs) => {
                 let lhs_evals = lhs.evaluate_on_domain(x_size, y_size, leaf_cache);
                 let rhs_evals = rhs.evaluate_on_domain(x_size, y_size, leaf_cache);
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step("fused_add_alloc", start, "evals", vec![x_size, y_size]);
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 ScalarCfg::add(&lhs_evals, &rhs_evals, &mut out, &vec_ops_cfg).unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step("fused_add_pointwise", start, "evals", vec![x_size, y_size]);
                 out
             }
             Self::Sub(lhs, rhs) => {
                 let lhs_evals = lhs.evaluate_on_domain(x_size, y_size, leaf_cache);
                 let rhs_evals = rhs.evaluate_on_domain(x_size, y_size, leaf_cache);
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step("fused_sub_alloc", start, "evals", vec![x_size, y_size]);
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 ScalarCfg::sub(&lhs_evals, &rhs_evals, &mut out, &vec_ops_cfg).unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step("fused_sub_pointwise", start, "evals", vec![x_size, y_size]);
                 out
             }
             Self::Mul(lhs, rhs) => {
                 let lhs_evals = lhs.evaluate_on_domain(x_size, y_size, leaf_cache);
                 let rhs_evals = rhs.evaluate_on_domain(x_size, y_size, leaf_cache);
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step("fused_mul_alloc", start, "evals", vec![x_size, y_size]);
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 ScalarCfg::mul(&lhs_evals, &rhs_evals, &mut out, &vec_ops_cfg).unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step("fused_mul_pointwise", start, "evals", vec![x_size, y_size]);
                 out
             }
             Self::Scale(scalar, expr) => {
@@ -329,8 +369,14 @@ impl<'a> PolyExpr<'a> {
                 if *scalar == ScalarField::one() {
                     return expr_evals;
                 }
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step("fused_scale_alloc", start, "evals", vec![x_size, y_size]);
                 let scaler = [*scalar];
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 ScalarCfg::scalar_mul(
                     HostSlice::from_slice(&scaler),
                     &expr_evals,
@@ -338,21 +384,49 @@ impl<'a> PolyExpr<'a> {
                     &vec_ops_cfg,
                 )
                 .unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step("fused_scale_pointwise", start, "evals", vec![x_size, y_size]);
                 out
             }
             Self::MulXMinusOne(expr) => {
                 let expr_evals = expr.evaluate_on_domain(x_size, y_size, leaf_cache);
                 let x_minus_one = x_minus_one_evals(x_size, y_size);
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 let mut out = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step(
+                    "fused_x_minus_one_alloc",
+                    start,
+                    "evals",
+                    vec![x_size, y_size],
+                );
+                #[cfg(feature = "timing")]
+                let start = Instant::now();
                 ScalarCfg::mul(&expr_evals, &x_minus_one, &mut out, &vec_ops_cfg).unwrap();
+                #[cfg(feature = "timing")]
+                record_detail_step(
+                    "fused_x_minus_one_pointwise",
+                    start,
+                    "evals",
+                    vec![x_size, y_size],
+                );
                 out
             }
             Self::Sum(terms) => {
                 let mut out = device_vec_from_scalar(ScalarField::zero(), size);
                 for term in terms {
                     let term_evals = term.evaluate_on_domain(x_size, y_size, leaf_cache);
+                    #[cfg(feature = "timing")]
+                    let start = Instant::now();
                     let mut next = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
+                    #[cfg(feature = "timing")]
+                    record_detail_step("fused_sum_alloc", start, "evals", vec![x_size, y_size]);
+                    #[cfg(feature = "timing")]
+                    let start = Instant::now();
                     ScalarCfg::add(&out, &term_evals, &mut next, &vec_ops_cfg).unwrap();
+                    #[cfg(feature = "timing")]
+                    record_detail_step("fused_sum_pointwise", start, "evals", vec![x_size, y_size]);
                     out = next;
                 }
                 out
@@ -391,14 +465,38 @@ fn eval_poly_leaf(
     let len = x_size * y_size;
     let key = (poly as *const DensePolynomialExt as usize, x_size, y_size);
     if let Some(cached) = leaf_cache.get(&key) {
+        #[cfg(feature = "timing")]
+        {
+            let start = Instant::now();
+            let out = copy_device_vec(cached, len);
+            record_detail_step("fused_leaf_cache_copy", start, "evals", vec![x_size, y_size]);
+            return out;
+        }
+        #[cfg(not(feature = "timing"))]
         return copy_device_vec(cached, len);
     }
 
+    #[cfg(feature = "timing")]
+    let start = Instant::now();
     let mut resized = poly.clone();
     resized.resize(x_size, y_size);
+    #[cfg(feature = "timing")]
+    record_detail_step("fused_leaf_resize", start, "coeffs", vec![x_size, y_size]);
+    #[cfg(feature = "timing")]
+    let start = Instant::now();
     let mut evals = DeviceVec::<ScalarField>::device_malloc(len).unwrap();
+    #[cfg(feature = "timing")]
+    record_detail_step("fused_leaf_alloc", start, "evals", vec![x_size, y_size]);
+    #[cfg(feature = "timing")]
+    let start = Instant::now();
     resized.to_rou_evals(None, None, &mut evals);
+    #[cfg(feature = "timing")]
+    record_detail_step("fused_leaf_to_rou_evals", start, "evals", vec![x_size, y_size]);
+    #[cfg(feature = "timing")]
+    let start = Instant::now();
     let out = copy_device_vec(&evals, len);
+    #[cfg(feature = "timing")]
+    record_detail_step("fused_leaf_output_copy", start, "evals", vec![x_size, y_size]);
     leaf_cache.insert(key, evals);
     out
 }

--- a/packages/backend/libs/src/tests.rs
+++ b/packages/backend/libs/src/tests.rs
@@ -56,6 +56,7 @@ mod tests {
     use super::*;
     use crate::bivariate_polynomial::{
         init_ntt_domain_for_size, BivariatePolynomial, DensePolynomialExt, DivByVanishingCache,
+        PolyExpr,
     };
     use crate::utils::check_device;
     // Helper function: Create a simple 2D polynomial
@@ -1228,6 +1229,45 @@ mod tests {
         let a = ScalarCfg::generate_random(1)[0];
         let b = ScalarCfg::generate_random(1)[0];
         assert!(p.eval(&a, &b).eq(&p_reconstruct.eval(&a, &b)));
+    }
+
+    #[test]
+    fn test_poly_expr_fused_matches_coefficients() {
+        init_bi_ntt_domain(4, 4);
+        let make_poly = || {
+            let coeffs = ScalarCfg::generate_random(4);
+            DensePolynomialExt::from_coeffs(HostSlice::from_slice(&coeffs), 2, 2)
+        };
+        let a = make_poly();
+        let b = make_poly();
+        let c = make_poly();
+        let d = make_poly();
+        let e = make_poly();
+
+        let expr = PolyExpr::weighted_sum(vec![
+            (
+                ScalarField::from_u32(7),
+                PolyExpr::mul_x_minus_one(PolyExpr::sub(
+                    PolyExpr::mul(PolyExpr::poly(&a), PolyExpr::poly(&b)),
+                    PolyExpr::mul(PolyExpr::poly(&c), PolyExpr::poly(&d)),
+                )),
+            ),
+            (
+                ScalarField::from_u32(11),
+                PolyExpr::mul(
+                    PolyExpr::sub(PolyExpr::poly(&a), PolyExpr::scalar(ScalarField::one())),
+                    PolyExpr::poly(&e),
+                ),
+            ),
+        ]);
+
+        let coeff_result = expr.evaluate_coeffs();
+        let fused_result = expr.evaluate_fused();
+        for _ in 0..8 {
+            let x = ScalarCfg::generate_random(1)[0];
+            let y = ScalarCfg::generate_random(1)[0];
+            assert_eq!(coeff_result.eval(&x, &y), fused_result.eval(&x, &y));
+        }
     }
 
     #[test]

--- a/packages/backend/libs/src/tests.rs
+++ b/packages/backend/libs/src/tests.rs
@@ -73,7 +73,9 @@ mod tests {
 
     fn init_bi_ntt_domain(x_size: usize, y_size: usize) {
         let size = x_size
+            .next_power_of_two()
             .checked_mul(y_size)
+            .and_then(|size| size.checked_next_power_of_two())
             .expect("x_size * y_size overflow in init_bi_ntt_domain");
         init_ntt_domain_for_size(size).unwrap();
     }
@@ -1038,12 +1040,13 @@ mod tests {
 
     #[test]
     fn test_mul_polynomial() {
-        let m = 11;
-        let n = 8;
+        let m = 5;
+        let n = 4;
         let p1_x_size = 2usize.pow(m);
         let p1_y_size = 2usize.pow(n);
         let p2_x_size = 2usize.pow(m);
         let p2_y_size = 2usize.pow(n);
+        init_bi_ntt_domain(p1_x_size + p2_x_size, p1_y_size + p2_y_size);
 
         let p1_coeffs_vec = ScalarCfg::generate_random(p1_x_size * p1_y_size);
         let p2_coeffs_vec = ScalarCfg::generate_random(p2_x_size * p2_y_size);
@@ -1088,6 +1091,7 @@ mod tests {
         if p_x_size % c != 0 || p_y_size % d != 0 {
             panic!("p_x_size and p_y_size must be divisible by c and d.");
         }
+        init_bi_ntt_domain(p_x_size, p_y_size);
         let m = p_x_size / c;
         let n = p_y_size / d;
         let mut t_x_coeffs = vec![ScalarField::zero(); 2 * c];
@@ -1165,6 +1169,7 @@ mod tests {
         if p_x_size % c != 0 || p_y_size % d != 0 {
             panic!("p_x_size and p_y_size must be divisible by c and d.");
         }
+        init_bi_ntt_domain(p_x_size, p_y_size);
         let m = p_x_size / c;
         let n = p_y_size / d;
         let mut t_x_coeffs = vec![ScalarField::zero(); 2 * c];
@@ -1210,8 +1215,8 @@ mod tests {
     // Test for div_by_vanishing - requires specific conditions
     #[test]
     fn test_div_by_vanishing_basic() {
-        let c = 1024;
-        let d = 256;
+        let c = 32;
+        let d = 16;
         run_div_by_vanishing_basic(2 * c, 2 * d, c, d);
         run_div_by_vanishing_basic(3 * c, 2 * d, c, d);
     }
@@ -1436,8 +1441,8 @@ mod tests {
 
     #[test]
     fn bench_denom_inv_ntt_vs_closed_form() {
-        let c = 2048;
-        let d = 256;
+        let c = 32;
+        let d = 16;
         let m = 4;
         let n = 2;
         let target_x = m * c;
@@ -1618,8 +1623,8 @@ mod tests_iotools {
 
     #[test]
     fn test_scalar_to_G1_conversion() {
-        let x_size = 2usize.pow(10);
-        let y_size = 2usize.pow(4);
+        let x_size = 2usize.pow(5);
+        let y_size = 2usize.pow(3);
         let x = ScalarCfg::generate_random(1)[0];
         let y = ScalarCfg::generate_random(1)[0];
         let gen = CurveCfg::generate_random_affine_points(1)[0];

--- a/packages/backend/prove/optimization/tests/timing.rs
+++ b/packages/backend/prove/optimization/tests/timing.rs
@@ -72,10 +72,27 @@ struct TimingReport {
 }
 
 #[cfg(feature = "timing")]
+#[derive(serde::Serialize)]
+struct CandidateBenchReport {
+    generated_at_unix_ms: u128,
+    repeats: usize,
+    setup_params: SetupParamsSummary,
+    results: Vec<prove::CandidateBenchResult>,
+}
+
+#[cfg(feature = "timing")]
 fn read_env(name: &str) -> Option<String> {
     env::var(name)
         .ok()
         .and_then(|v| if v.trim().is_empty() { None } else { Some(v) })
+}
+
+#[cfg(feature = "timing")]
+fn generated_at_unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
 }
 
 #[cfg(feature = "timing")]
@@ -191,13 +208,8 @@ fn timing_prove_stages() {
         }
     }
 
-    let generated_at_unix_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
-
     let report = TimingReport {
-        generated_at_unix_ms,
+        generated_at_unix_ms: generated_at_unix_ms(),
         total_wall_ms,
         setup_params,
         summary,
@@ -217,6 +229,112 @@ fn timing_prove_stages() {
     }
     if let Err(err) = fs::write(&out_path, report_json.as_bytes()) {
         eprintln!("Failed to write timing report to {:?}: {err}", out_path);
+    }
+}
+
+#[cfg(feature = "timing")]
+#[test]
+fn benchmark_fused_expression_candidates() {
+    if read_env("PROVE_CANDIDATE_BENCH").as_deref() != Some("1") {
+        eprintln!("Skipping candidate benchmark: PROVE_CANDIDATE_BENCH=1 is not set.");
+        return;
+    }
+    let qap_path = match read_env("PROVE_QAP_PATH") {
+        Some(v) => v,
+        None => {
+            eprintln!("Skipping candidate benchmark: PROVE_QAP_PATH is not set.");
+            return;
+        }
+    };
+    let synthesizer_path = match read_env("PROVE_SYNTHESIZER_PATH") {
+        Some(v) => v,
+        None => {
+            eprintln!("Skipping candidate benchmark: PROVE_SYNTHESIZER_PATH is not set.");
+            return;
+        }
+    };
+    let setup_path = match read_env("PROVE_SETUP_PATH") {
+        Some(v) => v,
+        None => {
+            eprintln!("Skipping candidate benchmark: PROVE_SETUP_PATH is not set.");
+            return;
+        }
+    };
+    let output_path = read_env("PROVE_OUT_PATH")
+        .unwrap_or_else(|| "tmp/candidate-bench-proof-output".to_string());
+    let repeats = read_env("PROVE_CANDIDATE_BENCH_REPEATS")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(2)
+        .max(1);
+
+    let paths = ProveInputPaths {
+        qap_path: &qap_path,
+        synthesizer_path: &synthesizer_path,
+        setup_path: &setup_path,
+        output_path: &output_path,
+    };
+
+    check_device();
+    let (mut prover, _binding) = Prover::init(&paths);
+    let setup_params = SetupParamsSummary {
+        l_free: prover.setup_params.l_free,
+        l: prover.setup_params.l,
+        l_user_out: prover.setup_params.l_user_out,
+        l_user: prover.setup_params.l_user,
+        l_D: prover.setup_params.l_D,
+        m_D: prover.setup_params.m_D,
+        n: prover.setup_params.n,
+        s_D: prover.setup_params.s_D,
+        s_max: prover.setup_params.s_max,
+    };
+
+    let mut manager = TranscriptManager::new();
+    let proof0 = prover.prove0();
+    let thetas = proof0.verify0_with_manager(&mut manager);
+    let proof1 = prover.prove1(&thetas);
+    let kappa0 = proof1.verify1_with_manager(&mut manager);
+    let proof2 = prover.prove2(&thetas, kappa0);
+    let (chi, zeta) = proof2.verify2_with_manager(&mut manager);
+    let proof3 = prover.prove3(chi, zeta);
+    let _kappa1 = proof3.verify3_with_manager(&mut manager);
+
+    let results = prover.benchmark_fused_expression_candidates(
+        &thetas,
+        kappa0,
+        chi,
+        zeta,
+        repeats,
+    );
+    for result in &results {
+        println!(
+            "{} baseline_avg={:.6}ms fused_avg={:.6}ms delta={:.6}ms dims={}x{}",
+            result.name,
+            result.baseline_avg_ms,
+            result.fused_avg_ms,
+            result.delta_avg_ms,
+            result.output_x_size,
+            result.output_y_size
+        );
+    }
+
+    let report = CandidateBenchReport {
+        generated_at_unix_ms: generated_at_unix_ms(),
+        repeats,
+        setup_params,
+        results,
+    };
+    let out_path = read_env("PROVE_CANDIDATE_BENCH_OUT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("tmp/fused-expression-candidate-bench.json"));
+    if let Some(parent) = out_path.parent() {
+        if let Err(err) = fs::create_dir_all(parent) {
+            eprintln!("Failed to create candidate benchmark report directory {parent:?}: {err}");
+        }
+    }
+    let report_json =
+        serde_json::to_string_pretty(&report).expect("failed to serialize candidate benchmark");
+    if let Err(err) = fs::write(&out_path, report_json.as_bytes()) {
+        eprintln!("Failed to write candidate benchmark report to {:?}: {err}", out_path);
     }
 }
 

--- a/packages/backend/prove/src/lib.rs
+++ b/packages/backend/prove/src/lib.rs
@@ -310,6 +310,132 @@ pub struct Prover {
     pub cache: ProverCache,
 }
 
+#[cfg(feature = "timing")]
+#[derive(Debug, Serialize)]
+pub struct CandidateBenchResult {
+    pub name: &'static str,
+    pub repeats: usize,
+    pub baseline_ms: Vec<f64>,
+    pub fused_ms: Vec<f64>,
+    pub baseline_avg_ms: f64,
+    pub fused_avg_ms: f64,
+    pub delta_avg_ms: f64,
+    pub output_x_size: usize,
+    pub output_y_size: usize,
+}
+
+#[cfg(feature = "timing")]
+fn average_ms(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<f64>() / values.len() as f64
+    }
+}
+
+#[cfg(feature = "timing")]
+fn assert_same_polynomial(
+    name: &str,
+    baseline: &DensePolynomialExt,
+    fused: &DensePolynomialExt,
+) {
+    let target_x_size = baseline.x_size.max(fused.x_size);
+    let target_y_size = baseline.y_size.max(fused.y_size);
+    let mut baseline_resized = baseline.clone();
+    baseline_resized.resize(target_x_size, target_y_size);
+    let mut fused_resized = fused.clone();
+    fused_resized.resize(target_x_size, target_y_size);
+
+    let len = target_x_size * target_y_size;
+    let mut baseline_coeffs = vec![ScalarField::zero(); len];
+    let mut fused_coeffs = vec![ScalarField::zero(); len];
+    baseline_resized.copy_coeffs(0, HostSlice::from_mut_slice(&mut baseline_coeffs));
+    fused_resized.copy_coeffs(0, HostSlice::from_mut_slice(&mut fused_coeffs));
+    assert_eq!(baseline_coeffs, fused_coeffs, "{name} fused benchmark mismatch");
+}
+
+#[cfg(feature = "timing")]
+fn benchmark_candidate_pair<Baseline, Fused>(
+    name: &'static str,
+    repeats: usize,
+    baseline: Baseline,
+    fused: Fused,
+) -> CandidateBenchResult
+where
+    Baseline: Fn() -> DensePolynomialExt,
+    Fused: Fn(usize, usize) -> DensePolynomialExt,
+{
+    let warmup_baseline = baseline();
+    let output_x_size = warmup_baseline.x_size;
+    let output_y_size = warmup_baseline.y_size;
+    let warmup_fused = fused(output_x_size, output_y_size);
+    assert_same_polynomial(name, &warmup_baseline, &warmup_fused);
+    drop(warmup_baseline);
+    drop(warmup_fused);
+
+    let mut baseline_ms = Vec::with_capacity(repeats);
+    let mut fused_ms = Vec::with_capacity(repeats);
+    for _ in 0..repeats {
+        let start = Instant::now();
+        let baseline_result = baseline();
+        baseline_ms.push(start.elapsed().as_secs_f64() * 1000.0);
+
+        let start = Instant::now();
+        let fused_result = fused(output_x_size, output_y_size);
+        fused_ms.push(start.elapsed().as_secs_f64() * 1000.0);
+
+        assert_same_polynomial(name, &baseline_result, &fused_result);
+        std::hint::black_box((baseline_result.x_size, fused_result.x_size));
+    }
+
+    let baseline_avg_ms = average_ms(&baseline_ms);
+    let fused_avg_ms = average_ms(&fused_ms);
+    CandidateBenchResult {
+        name,
+        repeats,
+        baseline_ms,
+        fused_ms,
+        baseline_avg_ms,
+        fused_avg_ms,
+        delta_avg_ms: fused_avg_ms - baseline_avg_ms,
+        output_x_size,
+        output_y_size,
+    }
+}
+
+#[cfg(feature = "timing")]
+fn lagrange_kl_xy(m_i: usize, s_max: usize) -> DensePolynomialExt {
+    let mut k_evals = vec![ScalarField::zero(); m_i];
+    k_evals[m_i - 1] = ScalarField::one();
+    let lagrange_k_xy =
+        DensePolynomialExt::from_rou_evals(HostSlice::from_slice(&k_evals), m_i, 1, None, None);
+
+    let mut l_evals = vec![ScalarField::zero(); s_max];
+    l_evals[s_max - 1] = ScalarField::one();
+    let lagrange_l_xy =
+        DensePolynomialExt::from_rou_evals(HostSlice::from_slice(&l_evals), 1, s_max, None, None);
+    &lagrange_k_xy * &lagrange_l_xy
+}
+
+#[cfg(feature = "timing")]
+fn lagrange_k0_xy(m_i: usize) -> DensePolynomialExt {
+    let mut k0_evals = vec![ScalarField::zero(); m_i];
+    k0_evals[0] = ScalarField::one();
+    DensePolynomialExt::from_rou_evals(HostSlice::from_slice(&k0_evals), m_i, 1, None, None)
+}
+
+#[cfg(feature = "timing")]
+fn x_monomial() -> DensePolynomialExt {
+    let coeffs = [ScalarField::zero(), ScalarField::one()];
+    DensePolynomialExt::from_coeffs(HostSlice::from_slice(&coeffs), 2, 1)
+}
+
+#[cfg(feature = "timing")]
+fn y_monomial() -> DensePolynomialExt {
+    let coeffs = [ScalarField::zero(), ScalarField::one()];
+    DensePolynomialExt::from_coeffs(HostSlice::from_slice(&coeffs), 1, 2)
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Proof {
     pub binding: Binding,
@@ -1077,6 +1203,244 @@ impl Prover {
             },
             binding,
         );
+    }
+
+    #[cfg(feature = "timing")]
+    pub fn benchmark_fused_expression_candidates(
+        &self,
+        thetas: &[ScalarField],
+        kappa0: ScalarField,
+        chi: ScalarField,
+        zeta: ScalarField,
+        repeats: usize,
+    ) -> Vec<CandidateBenchResult> {
+        let m_i = self.setup_params.l_D - self.setup_params.l;
+        let s_max = self.setup_params.s_max;
+        let kappa0_sq = kappa0.pow(2);
+        let omega_m_i = ntt::get_root_of_unity::<ScalarField>(m_i as u64);
+        let omega_s_max = ntt::get_root_of_unity::<ScalarField>(s_max as u64);
+
+        let r_omegaX = self.witness.rXY.scale_coeffs_x(&omega_m_i.inv());
+        let r_omegaX_omegaY = r_omegaX.scale_coeffs_y(&omega_s_max.inv());
+        let x_mono = x_monomial();
+        let y_mono = y_monomial();
+        let fXY = &(&(&self.witness.bXY + &(&thetas[0] * &self.instance.s0XY))
+            + &(&thetas[1] * &self.instance.s1XY))
+            + &thetas[2];
+        let gXY =
+            &(&(&self.witness.bXY + &(&thetas[0] * &x_mono)) + &(&thetas[1] * &y_mono))
+                + &thetas[2];
+        let lagrange_KL_XY = self
+            .cache
+            .lagrange_kl_xy
+            .clone()
+            .unwrap_or_else(|| lagrange_kl_xy(m_i, s_max));
+        let lagrange_K0_XY = lagrange_k0_xy(m_i);
+        let r_D1 = &self.witness.rXY - &r_omegaX;
+        let r_D2 = &self.witness.rXY - &r_omegaX_omegaY;
+        let g_D = &gXY - &fXY;
+
+        let term_B_zk = self.cache.term_b_zk.clone().unwrap_or_else(|| {
+            let rB_X_t_mi = low_degree_x_times_vanishing(&self.mixer.rB_X, m_i);
+            let rB_Y_t_smax = low_degree_y_times_vanishing(&self.mixer.rB_Y, s_max);
+            &rB_X_t_mi + &rB_Y_t_smax
+        });
+        let t_mi_eval = chi.pow(m_i) - ScalarField::one();
+        let t_s_max_eval = zeta.pow(s_max) - ScalarField::one();
+        let lagrange_K0_eval = lagrange_K0_XY.eval(&chi, &zeta);
+        let r_D1_eval = r_D1.eval(&chi, &zeta);
+        let r_D2_eval = r_D2.eval(&chi, &zeta);
+        let term10_scale = self.mixer.rR_X * t_mi_eval + self.mixer.rR_Y * t_s_max_eval;
+        let term10 = &term10_scale * &g_D;
+
+        let mut results = Vec::new();
+        results.push(benchmark_candidate_pair(
+            "prove0.p0XY",
+            repeats,
+            || &(&self.witness.uXY * &self.witness.vXY) - &self.witness.wXY,
+            |target_x_size, target_y_size| {
+                PolyExpr::sub(
+                    PolyExpr::mul(
+                        PolyExpr::poly(&self.witness.uXY),
+                        PolyExpr::poly(&self.witness.vXY),
+                    ),
+                    PolyExpr::poly(&self.witness.wXY),
+                )
+                .evaluate_fused_with_domain(target_x_size, target_y_size)
+            },
+        ));
+        results.push(benchmark_candidate_pair(
+            "prove2.Q_CX",
+            repeats,
+            || {
+                let rB_X_r_D1 = mul_by_linear_x(&r_D1, &self.mixer.rB_X);
+                let rB_X_r_D2 = mul_by_linear_x(&r_D2, &self.mixer.rB_X);
+                let d1_comb = &rB_X_r_D1 + &(&self.mixer.rR_X * &g_D);
+                let d2_comb = &rB_X_r_D2 + &(&self.mixer.rR_X * &g_D);
+                let x_minus_one_d1_comb = mul_by_x_minus_one(&d1_comb);
+                poly_comb!(
+                    (ScalarField::one(), self.quotients.q2XY),
+                    (self.mixer.rR_X, lagrange_KL_XY),
+                    (kappa0, x_minus_one_d1_comb),
+                    (kappa0_sq, &lagrange_K0_XY * &d2_comb)
+                )
+            },
+            |target_x_size, target_y_size| {
+                let rB_X_r_D1 = mul_by_linear_x(&r_D1, &self.mixer.rB_X);
+                let rB_X_r_D2 = mul_by_linear_x(&r_D2, &self.mixer.rB_X);
+                let d1_comb = &rB_X_r_D1 + &(&self.mixer.rR_X * &g_D);
+                let d2_comb = &rB_X_r_D2 + &(&self.mixer.rR_X * &g_D);
+                PolyExpr::weighted_sum(vec![
+                    (
+                        ScalarField::one(),
+                        PolyExpr::poly(&self.quotients.q2XY),
+                    ),
+                    (self.mixer.rR_X, PolyExpr::poly(&lagrange_KL_XY)),
+                    (kappa0, PolyExpr::mul_x_minus_one(PolyExpr::poly(&d1_comb))),
+                    (
+                        kappa0_sq,
+                        PolyExpr::mul(
+                            PolyExpr::poly(&lagrange_K0_XY),
+                            PolyExpr::poly(&d2_comb),
+                        ),
+                    ),
+                ])
+                .evaluate_fused_with_domain(target_x_size, target_y_size)
+            },
+        ));
+        results.push(benchmark_candidate_pair(
+            "prove2.Q_CY",
+            repeats,
+            || {
+                let rB_Y_r_D1 = mul_by_linear_y(&r_D1, &self.mixer.rB_Y);
+                let rB_Y_r_D2 = mul_by_linear_y(&r_D2, &self.mixer.rB_Y);
+                let d1_comb = &rB_Y_r_D1 + &(&self.mixer.rR_Y * &g_D);
+                let d2_comb = &rB_Y_r_D2 + &(&self.mixer.rR_Y * &g_D);
+                let x_minus_one_d1_comb = mul_by_x_minus_one(&d1_comb);
+                poly_comb!(
+                    (ScalarField::one(), self.quotients.q3XY),
+                    (self.mixer.rR_Y, lagrange_KL_XY),
+                    (kappa0, x_minus_one_d1_comb),
+                    (kappa0_sq, &lagrange_K0_XY * &d2_comb)
+                )
+            },
+            |target_x_size, target_y_size| {
+                let rB_Y_r_D1 = mul_by_linear_y(&r_D1, &self.mixer.rB_Y);
+                let rB_Y_r_D2 = mul_by_linear_y(&r_D2, &self.mixer.rB_Y);
+                let d1_comb = &rB_Y_r_D1 + &(&self.mixer.rR_Y * &g_D);
+                let d2_comb = &rB_Y_r_D2 + &(&self.mixer.rR_Y * &g_D);
+                PolyExpr::weighted_sum(vec![
+                    (
+                        ScalarField::one(),
+                        PolyExpr::poly(&self.quotients.q3XY),
+                    ),
+                    (self.mixer.rR_Y, PolyExpr::poly(&lagrange_KL_XY)),
+                    (kappa0, PolyExpr::mul_x_minus_one(PolyExpr::poly(&d1_comb))),
+                    (
+                        kappa0_sq,
+                        PolyExpr::mul(
+                            PolyExpr::poly(&lagrange_K0_XY),
+                            PolyExpr::poly(&d2_comb),
+                        ),
+                    ),
+                ])
+                .evaluate_fused_with_domain(target_x_size, target_y_size)
+            },
+        ));
+        results.push(benchmark_candidate_pair(
+            "prove4.LHS_zk1",
+            repeats,
+            || {
+                let r_D1_term9 = mul_by_term9(
+                    &r_D1,
+                    &self.mixer.rB_X,
+                    &self.mixer.rB_Y,
+                    &t_mi_eval,
+                    &t_s_max_eval,
+                );
+                let r_d1_term9_plus_term10 = &r_D1_term9 + &term10;
+                let one_minus_x_times = mul_by_one_minus_x(&r_d1_term9_plus_term10);
+                poly_comb!(
+                    ((chi - ScalarField::one()) * r_D1_eval, term_B_zk),
+                    (ScalarField::one(), one_minus_x_times),
+                    (chi - ScalarField::one(), term10)
+                )
+            },
+            |target_x_size, target_y_size| {
+                let r_D1_term9 = mul_by_term9(
+                    &r_D1,
+                    &self.mixer.rB_X,
+                    &self.mixer.rB_Y,
+                    &t_mi_eval,
+                    &t_s_max_eval,
+                );
+                let sum_expr = PolyExpr::add(
+                    PolyExpr::poly(&r_D1_term9),
+                    PolyExpr::poly(&term10),
+                );
+                let one_minus_x_expr = PolyExpr::scale(
+                    ScalarField::zero() - ScalarField::one(),
+                    PolyExpr::mul_x_minus_one(sum_expr),
+                );
+                PolyExpr::weighted_sum(vec![
+                    (
+                        (chi - ScalarField::one()) * r_D1_eval,
+                        PolyExpr::poly(&term_B_zk),
+                    ),
+                    (ScalarField::one(), one_minus_x_expr),
+                    (chi - ScalarField::one(), PolyExpr::poly(&term10)),
+                ])
+                .evaluate_fused_with_domain(target_x_size, target_y_size)
+            },
+        ));
+        results.push(benchmark_candidate_pair(
+            "prove4.LHS_zk2",
+            repeats,
+            || {
+                let r_D2_term9 = mul_by_term9(
+                    &r_D2,
+                    &self.mixer.rB_X,
+                    &self.mixer.rB_Y,
+                    &t_mi_eval,
+                    &t_s_max_eval,
+                );
+                let r_d2_term9_plus_term10 = &r_D2_term9 + &term10;
+                poly_comb!(
+                    (lagrange_K0_eval * r_D2_eval, term_B_zk),
+                    (lagrange_K0_eval, term10),
+                    (
+                        ScalarField::zero() - ScalarField::one(),
+                        &lagrange_K0_XY * &r_d2_term9_plus_term10
+                    )
+                )
+            },
+            |target_x_size, target_y_size| {
+                let r_D2_term9 = mul_by_term9(
+                    &r_D2,
+                    &self.mixer.rB_X,
+                    &self.mixer.rB_Y,
+                    &t_mi_eval,
+                    &t_s_max_eval,
+                );
+                let sum_expr = PolyExpr::add(
+                    PolyExpr::poly(&r_D2_term9),
+                    PolyExpr::poly(&term10),
+                );
+                PolyExpr::weighted_sum(vec![
+                    (
+                        lagrange_K0_eval * r_D2_eval,
+                        PolyExpr::poly(&term_B_zk),
+                    ),
+                    (lagrange_K0_eval, PolyExpr::poly(&term10)),
+                    (
+                        ScalarField::zero() - ScalarField::one(),
+                        PolyExpr::mul(PolyExpr::poly(&lagrange_K0_XY), sum_expr),
+                    ),
+                ])
+                .evaluate_fused_with_domain(target_x_size, target_y_size)
+            },
+        ));
+        results
     }
 
     pub fn prove0(&mut self) -> Proof0 {

--- a/packages/backend/prove/src/lib.rs
+++ b/packages/backend/prove/src/lib.rs
@@ -37,6 +37,14 @@ macro_rules! poly_comb {
         }};
     }
 
+#[cfg(feature = "timing")]
+fn use_coeff_backend_for_prove2_p_comb_timing() -> bool {
+    std::env::var("TOKAMAK_PROVE2_PCOMB_BACKEND")
+        .ok()
+        .as_deref()
+        == Some("coeff")
+}
+
 fn low_degree_x_times_vanishing(coeffs: &[ScalarField], exponent: usize) -> DensePolynomialExt {
     assert!(exponent > 0);
     let x_size = (exponent + coeffs.len()).next_power_of_two();
@@ -1755,12 +1763,23 @@ impl Prover {
                     ),
                 );
 
-                PolyExpr::weighted_sum(vec![
+                let expr = PolyExpr::weighted_sum(vec![
                     (ScalarField::one(), p1XY),
                     (kappa0, p2XY),
                     (kappa0_sq, p3XY),
-                ])
-                .evaluate_fused_with_domain(4 * m_i, 2 * s_max)
+                ]);
+                #[cfg(feature = "timing")]
+                {
+                    if use_coeff_backend_for_prove2_p_comb_timing() {
+                        expr.evaluate_coeffs()
+                    } else {
+                        expr.evaluate_fused_with_domain(4 * m_i, 2 * s_max)
+                    }
+                }
+                #[cfg(not(feature = "timing"))]
+                {
+                    expr.evaluate_fused_with_domain(4 * m_i, 2 * s_max)
+                }
             }
         );
         (self.quotients.q2XY, self.quotients.q3XY) = crate::time_block!(

--- a/packages/backend/prove/src/lib.rs
+++ b/packages/backend/prove/src/lib.rs
@@ -3,7 +3,7 @@ use icicle_bls12_381::curve::{ScalarCfg, ScalarField};
 use icicle_core::ntt;
 use icicle_core::traits::{Arithmetic, FieldImpl, GenerateRandom};
 use icicle_runtime::memory::HostSlice;
-use libs::bivariate_polynomial::{BivariatePolynomial, DensePolynomialExt};
+use libs::bivariate_polynomial::{BivariatePolynomial, DensePolynomialExt, PolyExpr};
 use libs::field_structures::FieldSerde;
 use libs::group_structures::G1serde;
 use libs::iotools::*;
@@ -1735,20 +1735,32 @@ impl Prover {
                 dims: vec![m_i, s_max]
             },],
             {
-                // Original expression computed `self.witness.rXY * gXY` separately in p2XY and p3XY.
-                let r_gXY = &self.witness.rXY * &gXY;
-                let p1XY = &(&self.witness.rXY - &ScalarField::one()) * &(lagrange_KL_XY);
-                // Original expression:
-                // p2XY = (X - 1) * (r_gXY - r_omegaX * fXY).
-                let p2_input = &r_gXY - &(&r_omegaX * &fXY);
-                let p2XY = mul_by_x_minus_one(&p2_input);
-                let p3XY = &lagrange_K0_XY * &(&r_gXY - &(&r_omegaX_omegaY * &fXY));
+                let r_gXY = PolyExpr::mul(PolyExpr::poly(&self.witness.rXY), PolyExpr::poly(&gXY));
+                let p1XY = PolyExpr::mul(
+                    PolyExpr::sub(
+                        PolyExpr::poly(&self.witness.rXY),
+                        PolyExpr::scalar(ScalarField::one()),
+                    ),
+                    PolyExpr::poly(&lagrange_KL_XY),
+                );
+                let p2XY = PolyExpr::mul_x_minus_one(PolyExpr::sub(
+                    r_gXY.clone(),
+                    PolyExpr::mul(PolyExpr::poly(&r_omegaX), PolyExpr::poly(&fXY)),
+                ));
+                let p3XY = PolyExpr::mul(
+                    PolyExpr::poly(&lagrange_K0_XY),
+                    PolyExpr::sub(
+                        r_gXY,
+                        PolyExpr::mul(PolyExpr::poly(&r_omegaX_omegaY), PolyExpr::poly(&fXY)),
+                    ),
+                );
 
-                poly_comb!(
+                PolyExpr::weighted_sum(vec![
                     (ScalarField::one(), p1XY),
                     (kappa0, p2XY),
-                    (kappa0_sq, p3XY)
-                )
+                    (kappa0_sq, p3XY),
+                ])
+                .evaluate_fused_with_domain(4 * m_i, 2 * s_max)
             }
         );
         (self.quotients.q2XY, self.quotients.q3XY) = crate::time_block!(

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-zk-evm/cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Tokamak zk-EVM CLI for installing the local prover runtime and running synthesize, preprocess, prove, verify, and proof export commands.",
   "keywords": [
     "cli",
@@ -60,7 +60,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@tokamak-zk-evm/synthesizer-node": "^2.1.2",
+    "@tokamak-zk-evm/synthesizer-node": "^2.1.3",
     "adm-zip": "^0.5.17"
   },
   "devDependencies": {

--- a/packages/frontend/qap-compiler/package-lock.json
+++ b/packages/frontend/qap-compiler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokamak-zk-evm/subcircuit-library",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokamak-zk-evm/subcircuit-library",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "os": [

--- a/packages/frontend/qap-compiler/package.json
+++ b/packages/frontend/qap-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-zk-evm/subcircuit-library",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Prebuilt R1CS subcircuit library package for Tokamak zk-EVM",
   "private": true,
   "keywords": [

--- a/packages/frontend/synthesizer/node-cli/package-lock.json
+++ b/packages/frontend/synthesizer/node-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokamak-zk-evm/synthesizer-node",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokamak-zk-evm/synthesizer-node",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@ethereumjs/block": "^10.0.0",
@@ -19,7 +19,7 @@
         "@ethereumjs/vm": "^10.0.0",
         "@js-sdsl/ordered-map": "^4.4.2",
         "@noble/curves": "1.9.7",
-        "@tokamak-zk-evm/subcircuit-library": "^2.1.2",
+        "@tokamak-zk-evm/subcircuit-library": "^2.1.3",
         "@types/debug": "^4.1.9",
         "@vitest/coverage-v8": "^2.1.8",
         "@zk-kit/imt": "2.0.0-beta.8",

--- a/packages/frontend/synthesizer/node-cli/package.json
+++ b/packages/frontend/synthesizer/node-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-zk-evm/synthesizer-node",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Node CLI for running the Tokamak zk-EVM synthesizer against JSON transaction snapshot inputs.",
   "keywords": [
     "ethereum",
@@ -91,7 +91,7 @@
     "@ethereumjs/vm": "^10.0.0",
     "@js-sdsl/ordered-map": "^4.4.2",
     "@noble/curves": "1.9.7",
-    "@tokamak-zk-evm/subcircuit-library": "^2.1.2",
+    "@tokamak-zk-evm/subcircuit-library": "^2.1.3",
     "@types/debug": "^4.1.9",
     "@vitest/coverage-v8": "^2.1.8",
     "@zk-kit/imt": "2.0.0-beta.8",

--- a/packages/frontend/synthesizer/package-lock.json
+++ b/packages/frontend/synthesizer/package-lock.json
@@ -12530,7 +12530,7 @@
     },
     "node-cli": {
       "name": "@tokamak-zk-evm/synthesizer-node",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@ethereumjs/block": "^10.0.0",
@@ -12543,7 +12543,7 @@
         "@ethereumjs/vm": "^10.0.0",
         "@js-sdsl/ordered-map": "^4.4.2",
         "@noble/curves": "1.9.7",
-        "@tokamak-zk-evm/subcircuit-library": "^2.1.2",
+        "@tokamak-zk-evm/subcircuit-library": "^2.1.3",
         "@types/debug": "^4.1.9",
         "@vitest/coverage-v8": "^2.1.8",
         "@zk-kit/imt": "2.0.0-beta.8",
@@ -12603,7 +12603,7 @@
     },
     "web-app": {
       "name": "@tokamak-zk-evm/synthesizer-web",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@ethereumjs/block": "^10.0.0",
@@ -12612,7 +12612,7 @@
         "@ethereumjs/util": "^10.0.0",
         "@ethereumjs/vm": "^10.0.0",
         "@noble/curves": "1.9.7",
-        "@tokamak-zk-evm/subcircuit-library": "^2.1.2",
+        "@tokamak-zk-evm/subcircuit-library": "^2.1.3",
         "@zk-kit/imt": "2.0.0-beta.8",
         "tokamak-l2js": "^0.1.4"
       },

--- a/packages/frontend/synthesizer/web-app/package-lock.json
+++ b/packages/frontend/synthesizer/web-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokamak-zk-evm/synthesizer-web",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokamak-zk-evm/synthesizer-web",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@ethereumjs/block": "^10.0.0",
@@ -17,7 +17,7 @@
         "@noble/curves": "1.9.7",
         "@zk-kit/imt": "2.0.0-beta.8",
         "tokamak-l2js": "^0.1.4",
-        "@tokamak-zk-evm/subcircuit-library": "^2.1.2"
+        "@tokamak-zk-evm/subcircuit-library": "^2.1.3"
       },
       "devDependencies": {
         "@types/node": "^22.15.14",

--- a/packages/frontend/synthesizer/web-app/package.json
+++ b/packages/frontend/synthesizer/web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-zk-evm/synthesizer-web",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Browser-facing Tokamak zk-EVM synthesizer package with bundled subcircuit library assets.",
   "keywords": [
     "ethereum",
@@ -65,7 +65,7 @@
     "@ethereumjs/util": "^10.0.0",
     "@ethereumjs/vm": "^10.0.0",
     "@noble/curves": "1.9.7",
-    "@tokamak-zk-evm/subcircuit-library": "^2.1.2",
+    "@tokamak-zk-evm/subcircuit-library": "^2.1.3",
     "@zk-kit/imt": "2.0.0-beta.8",
     "tokamak-l2js": "^0.1.4"
   },


### PR DESCRIPTION
## Summary

This release adds a typed polynomial expression evaluator to the Rust backend and uses a fused evaluation-domain path for the prover's `prove2.p_comb` expression. It also adds correctness coverage and timing diagnostics for evaluating further fusion candidates, while synchronizing the repository release version to `2.1.3`.

## Backend changes

- Adds `PolyExpr` as the single expression boundary for scaled bivariate polynomial terms.
- Supports both coefficient-domain evaluation and fused evaluation-domain execution that converts the completed expression back to the existing coefficient-domain polynomial representation.
- Applies fused evaluation to `prove2.p_comb` and retains a timing-only coefficient-domain baseline for controlled comparisons.
- Adds focused tests that compare fused and coefficient-domain results across representative expression shapes.
- Adds prover operation diagnostics and candidate benchmarks for `Q_CY`, `Q_CX`, `LHS_zk2`, and related polynomial combinations.
- Serializes backend Rust test execution and makes NTT domain initialization reusable so repeated test setup is stable.
- Corrects stale VS Code backend launch arguments and ignores backend-local temporary planning files.

## Prover timing comparison

The comparison used the local CPU fallback backend, the same source revision, release build, fixture set, setup artifacts, and timing boundaries. The coefficient baseline was selected with `TOKAMAK_PROVE2_PCOMB_BACKEND=coeff`. Runs were ordered `coefficient -> fused -> fused -> coefficient` to reduce run-order bias; the table reports the mean of the two runs for each path.

| Metric | Coefficient baseline | Fused expression | Delta | Change |
| --- | ---: | ---: | ---: | ---: |
| `poly.combine.prove2.p_comb` | 5.238042 s | 4.114520 s | -1.123523 s | -21.45% |
| `prove2.poly` | 6.741060 s | 5.679763 s | -1.061296 s | -15.74% |
| Total polynomial time | 13.709299 s | 12.763110 s | -0.946189 s | -6.90% |
| Full prove wall time | 43.058889 s | 43.133538 s | +0.074649 s | +0.17% |

The targeted `p_comb` improvement was consistent in both pairs. The coefficient path performs twelve operand forward NTTs and six product inverse NTTs for six generic products; the fused path performs seven unique leaf forward NTTs and one final inverse NTT. Full wall time remained within local run-to-run noise and did not improve in this strict re-comparison, so this PR does not claim a measured end-to-end wall-time reduction.

## Version and changelog

- Bumps the synchronized repository, CLI, subcircuit library, synthesizer, and backend workspace versions from `2.1.2` to `2.1.3`.
- Updates synchronized internal package dependency ranges to `^2.1.3`.
- Adds the `2.1.3` release entry to the root changelog.

## Validation

- `npm run version:check`
- `cargo test -p libs --lib` (38 passed, 3 ignored)
- `cargo test -p prove --features timing --test timing --no-run`
- `git diff --check origin/main..HEAD`

`cargo fmt --all --check` could not run because `rustfmt` is not installed for the local `stable-aarch64-apple-darwin` toolchain.
